### PR TITLE
Tests: Make the bundledImages absolute-root check platform-independent

### DIFF
--- a/tests/bundledImages.test.mts
+++ b/tests/bundledImages.test.mts
@@ -26,7 +26,7 @@ import { test } from 'node:test'
 import assert from 'node:assert/strict'
 import { createHash } from 'node:crypto'
 import { existsSync, readFileSync } from 'node:fs'
-import { dirname, isAbsolute, join } from 'node:path'
+import { dirname, join, win32 } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import {
   BUNDLED_IMAGES_DIR_NAME,
@@ -67,7 +67,11 @@ test('bundledImageRoots drops the resources root when there is no resourcesPath'
   // would resolve against whatever the cwd happened to be. It must not be in the list at all.
   const roots = bundledImageRoots({ ...PATHS, resourcesPath: '' })
   assert.equal(roots.length, 3)
-  for (const r of roots) assert.ok(isAbsolute(r), `root is relative and would follow the cwd: ${r}`)
+  // `win32.isAbsolute`, not the platform's: PATHS is win32-shaped, and off Windows the bare
+  // `isAbsolute` reads 'C:/app/...' as relative — it would fail on the fixture, not the code.
+  // The leak this guards still reads relative under win32 rules ('wiki-images'), so it still bites.
+  for (const r of roots)
+    assert.ok(win32.isAbsolute(r), `root is relative and would follow the cwd: ${r}`)
 })
 
 test('findBundledImagesDir returns the FIRST root that exists', () => {


### PR DESCRIPTION
`bundledImageRoots drops the resources root when there is no resourcesPath` fails on macOS and Linux.

The fixture is win32-shaped (`join('C:', 'app', ...)`), but `isAbsolute` follows the host platform. Off Windows, `C:/app/resources/app.asar/resources/wiki-images` reads as relative, so the assertion trips on the fixture instead of the code. `build.yml` runs the suite on `windows-latest` only, which is why CI stays green.

This switches that one assertion to `win32.isAbsolute`, matching the flavor the fixture is written in. The leak it guards still fails the check: an empty `resourcesPath` would leave a bare `wiki-images`, and win32 reads that as relative too.

`bundledImages.ts` is unchanged. It's already platform-clean, and the `length === 3` assert above passes everywhere.

Found this running the suite on macOS (Node 24), where it's the only failure out of 3360.
