### PR TITLE
Sky: a held quest reward marks its quest turned in (fixes #27)

### DIFF
--- a/src/renderer/src/features/posky/IgnoredList.tsx
+++ b/src/renderer/src/features/posky/IgnoredList.tsx
@@ -55,7 +55,7 @@ export function IgnoredList({
               </Typography>
             )}
             <Box sx={{ flexGrow: 1 }} />
-            <TurnInBadge count={q.turnIns} />
+            <TurnInBadge count={q.turnIns} inferred={q.rewardInferred} />
           </Stack>
         ))}
       </Stack>

--- a/src/renderer/src/features/posky/QuestAccordion.tsx
+++ b/src/renderer/src/features/posky/QuestAccordion.tsx
@@ -234,7 +234,7 @@ function QuestSummaryRow({
       {/* BOTH, since JOS-131. The turn-in badge is history ("you have done this, twice"); the
           chip beside it is the present ("and right now you are three items short of doing it
           again"). Collapsing them into one chip is what used to make a re-run invisible. */}
-      <TurnInBadge count={q.turnIns} />
+      <TurnInBadge count={q.turnIns} inferred={q.rewardInferred} />
       <Chip
         size="small"
         variant="outlined"

--- a/src/renderer/src/features/posky/TurnInControls.tsx
+++ b/src/renderer/src/features/posky/TurnInControls.tsx
@@ -26,8 +26,20 @@ import type { QuestProgress } from './useProgress'
  * so would be noise on most of the list. The count appears from the second turn-in on
  * (`turnInBadgeLabel`), so the common case stays the plain "Turned in" it has always been.
  * `data-count` states the number a test can read without parsing the label.
+ *
+ * `inferred` is the issue-#27 reading — the count exists because the quest's REWARD is in the
+ * loaded inventory export, not because a turn-in was logged or stated — and the hover says so,
+ * because a reader who cannot tell "the log said so" from "we worked it out" cannot tell which
+ * rows to trust (classUnlocks.ts). `data-inferred` states it for a test the same way
+ * `data-count` states the number.
  */
-export function TurnInBadge({ count }: { count: number }): JSX.Element | null {
+export function TurnInBadge({
+  count,
+  inferred
+}: {
+  count: number
+  inferred?: boolean
+}): JSX.Element | null {
   if (count <= 0) return null
   return (
     <Chip
@@ -36,10 +48,13 @@ export function TurnInBadge({ count }: { count: number }): JSX.Element | null {
       variant="outlined"
       data-testid="posky-turned-in"
       data-count={count}
+      data-inferred={inferred ? 'true' : undefined}
       title={
-        count > 1
-          ? `Turned in ${String(count)} times. Each turn-in spends the items it required, so the progress beside this is what you hold toward doing it again.`
-          : 'Turned in once. The items it required were spent, so the progress beside this is what you hold toward doing it again.'
+        inferred
+          ? 'Turned in at least once: the reward for this quest is in your inventory export, and it cannot be obtained any other way.'
+          : count > 1
+            ? `Turned in ${String(count)} times. Each turn-in spends the items it required, so the progress beside this is what you hold toward doing it again.`
+            : 'Turned in once. The items it required were spent, so the progress beside this is what you hold toward doing it again.'
       }
       label={turnInBadgeLabel(count)}
     />
@@ -48,7 +63,9 @@ export function TurnInBadge({ count }: { count: number }): JSX.Element | null {
 
 /** The undo button, with the one thing it has to say for itself when it cannot act. */
 function UndoTurnIn({ q, onUndo }: { q: QuestProgress; onUndo: () => void }): JSX.Element {
-  const canUndo = q.turnIns > q.logTurnIns
+  // An INFERRED count (issue #27) cannot be taken back for the same reason a log-detected one
+  // cannot: the evidence (the reward in your export) would simply re-assert it on the next read.
+  const canUndo = !q.rewardInferred && q.turnIns > q.logTurnIns
   return (
     // The span outlives the tooltip that needed it, for the same reason: a DISABLED button
     // swallows no mouse events, and "why is this dead" is exactly the question the words answer.
@@ -56,9 +73,11 @@ function UndoTurnIn({ q, onUndo }: { q: QuestProgress; onUndo: () => void }): JS
       title={
         canUndo
           ? 'Take back the most recent turn-in you recorded by hand'
-          : q.turnIns === 0
-            ? 'Nothing to take back'
-            : 'This count comes from your log, so it cannot be taken back here'
+          : q.rewardInferred
+            ? 'This count comes from the reward in your inventory export, so it cannot be taken back here'
+            : q.turnIns === 0
+              ? 'Nothing to take back'
+              : 'This count comes from your log, so it cannot be taken back here'
       }
     >
       <IconButton size="small" data-testid="posky-undo-turnin" disabled={!canUndo} onClick={onUndo}>

--- a/src/renderer/src/features/posky/rewardInference.ts
+++ b/src/renderer/src/features/posky/rewardInference.ts
@@ -1,0 +1,83 @@
+// ============================================================================
+// rewardInference.ts — the reward item in your inventory export IS evidence (issue #27).
+// ============================================================================
+//
+// THE REPORT: a fresh install loads an inventory export that plainly contains a Sky quest's
+// reward, and the quest still reads "not turned in". Nothing was broken — nothing ever consulted
+// the reward. The ledger (shared/questTurnIns.ts) has three sources: log-detected trades, hand
+// statements, and the legacy `completedQuests` key. A turn-in done before logging was on leaves
+// none of those, and rotating a log un-completes history the same way.
+//
+// WHY POSSESSION IS PROOF, measured against the committed data (2026-08-16): all 95 Sky quests
+// have a reward, every reward is UNIQUE to its quest, none appears as a drop anywhere in the
+// items DB, none is consumed as another Sky quest's required item, and 92 of the 94 in the DB
+// are NO DROP. The rewards cannot be obtained without doing the quest, so holding one proves at
+// least one turn-in as surely as a log line would.
+//
+// WHAT THE INFERENCE IS — a DERIVED floor of one, in the classUnlocks.ts mold (observed wins,
+// derived is labelled) and on the legacy `completedQuests` precedent (a completion that is real
+// but undated floors the count at 1 and says nothing else):
+//   * applied AFTER `computeQuestProgress`, never written to the ledger. Consumption never sees
+//     it (an inferred turn-in predates the log, so its items were never in the log counts and it
+//     owes no subtraction — the "a dump owes none" rule, reconcile.ts), the celebration baseline
+//     never sees it (no false toast on first load), and nothing is persisted (the export is
+//     re-read every time, so the reading can never go stale in a store);
+//   * LABELLED (`rewardInferred`), and only present when it is the count's ONLY source — any
+//     ledger evidence wins and leaves the row exactly as the ledger said it;
+//   * ONE-DIRECTIONAL. Reward present ⇒ turned in; reward ABSENT proves nothing, because the
+//     export only covers what was open when it was written (a banked reward is invisible — the
+//     owner's own store has two turned-in quests whose rewards the export never saw). Nothing
+//     here un-completes anything, which is the promise "a dump adds, it never subtracts"
+//     already makes about counts.
+//
+// The match is on the COUNTING key (`itemCountKey`: lowercased, ` +N` folded), because the
+// export's keys are raw names lowercased (heldCountsFromDump) and a reward the player has
+// exalted to `+2` is still the quest's reward.
+
+import type { PoskyQuest } from '@shared/types'
+import { itemCountKey } from '../../lib/itemName'
+import { questKey } from './keys'
+import type { QuestProgress } from './useProgress'
+
+/**
+ * Which quests the loaded export vouches for: every quest whose reward item the inventory holds.
+ *
+ * `inventory` is `ProgressState.inventory` as stored — raw names lowercased, `+N` variants NOT
+ * yet folded — so the fold happens here, on both sides of the match. A count of zero or less is
+ * an absent item: the parser never writes one, so it can only mean a hand-edited store, and an
+ * item you hold none of vouches for nothing.
+ */
+export function rewardInferredQuests(
+  quests: readonly Pick<PoskyQuest, 'className' | 'name' | 'reward'>[],
+  inventory: Record<string, number> | undefined
+): Set<string> {
+  const vouched = new Set<string>()
+  if (!inventory) return vouched
+  const held = new Set<string>()
+  for (const [name, count] of Object.entries(inventory)) {
+    if (count > 0) held.add(itemCountKey(name))
+  }
+  for (const q of quests) {
+    // A quest with no reward in the data never infers: that is missing data about a quest, not
+    // a finished one (the `hasEveryItem` refusal, law 1).
+    if (q.reward !== undefined && held.has(itemCountKey(q.reward))) vouched.add(questKey(q))
+  }
+  return vouched
+}
+
+/**
+ * The floor: a vouched-for quest with NO other evidence reads turnIns 1 / completed, labelled.
+ *
+ * Applied per row after `computeQuestProgress`, the way `firstTimeReady` narrows `readyQuests` —
+ * a composition, not a rewrite — so every downstream reading of `turnIns` (`everTurnedIn`, the
+ * hide-turned-in box, the class-unlock derivation, the Ready tab's first-time default) agrees
+ * without consulting a second field. `logTurnIns` stays 0: the log's share is a fact about the
+ * log, and this is not log evidence.
+ */
+export function withRewardInference(
+  q: QuestProgress,
+  vouched: ReadonlySet<string>
+): QuestProgress {
+  if (q.turnIns > 0 || !vouched.has(q.key)) return q
+  return { ...q, turnIns: 1, completed: true, rewardInferred: true }
+}

--- a/src/renderer/src/features/posky/rewardInference.ts
+++ b/src/renderer/src/features/posky/rewardInference.ts
@@ -11,8 +11,17 @@
 // WHY POSSESSION IS PROOF, measured against the committed data (2026-08-16): all 95 Sky quests
 // have a reward, every reward is UNIQUE to its quest, none appears as a drop anywhere in the
 // items DB, none is consumed as another Sky quest's required item, and 92 of the 94 in the DB
-// are NO DROP. The rewards cannot be obtained without doing the quest, so holding one proves at
-// least one turn-in as surely as a log line would.
+// are NO DROP or No Trade. For THOSE, holding the reward proves at least one turn-in as surely
+// as a log line would - an item that cannot move has exactly one way into a bag.
+//
+// THE TWO THAT CAN MOVE PROVE NOTHING, and the gate below is that sentence as code. Bloody
+// Griffon-Hide Wrist Guard and Sphinx Heart Amulet (both Necromancer rewards) carry no
+// NO DROP / No Trade flag: they can be bought or handed over, so possession is not evidence and
+// inferring from it would mark a quest done that never ran - with the undo control honestly
+// disabled, leaving no way to say otherwise. So the inference fires only when the reward's own
+// stat blob states it cannot be traded, in either spelling the scrape uses ("NO DROP" on the
+// classic pages, "Lore Equipped, No Trade" on the newer ones). Those two quests simply never
+// infer, which is the status quo they had before this module existed.
 //
 // WHAT THE INFERENCE IS — a DERIVED floor of one, in the classUnlocks.ts mold (observed wins,
 // derived is labelled) and on the legacy `completedQuests` precedent (a completion that is real
@@ -40,7 +49,19 @@ import { questKey } from './keys'
 import type { QuestProgress } from './useProgress'
 
 /**
- * Which quests the loaded export vouches for: every quest whose reward item the inventory holds.
+ * Does the reward's own stat blob say it cannot be traded? Both spellings the scrape carries:
+ * "NO DROP" (the classic wiki pages) and "No Trade" (the newer ones, sometimes "LORE ITEM NO
+ * TRADE"). An ABSENT or silent blob reads as tradeable - the conservative side of the gate,
+ * because the failure modes are asymmetric: not inferring costs a badge the user can still
+ * record by hand, while inferring falsely marks a quest done with the undo honestly disabled.
+ */
+function isUntradeable(rewardStats: string | undefined): boolean {
+  return /no[ -]?(drop|trade)/i.test(rewardStats ?? '')
+}
+
+/**
+ * Which quests the loaded export vouches for: every quest whose UNTRADEABLE reward item the
+ * inventory holds (the header's gate - a reward that can move proves nothing).
  *
  * `inventory` is `ProgressState.inventory` as stored — raw names lowercased, `+N` variants NOT
  * yet folded — so the fold happens here, on both sides of the match. A count of zero or less is
@@ -48,7 +69,7 @@ import type { QuestProgress } from './useProgress'
  * item you hold none of vouches for nothing.
  */
 export function rewardInferredQuests(
-  quests: readonly Pick<PoskyQuest, 'className' | 'name' | 'reward'>[],
+  quests: readonly Pick<PoskyQuest, 'className' | 'name' | 'reward' | 'rewardStats'>[],
   inventory: Record<string, number> | undefined
 ): Set<string> {
   const vouched = new Set<string>()
@@ -59,8 +80,10 @@ export function rewardInferredQuests(
   }
   for (const q of quests) {
     // A quest with no reward in the data never infers: that is missing data about a quest, not
-    // a finished one (the `hasEveryItem` refusal, law 1).
-    if (q.reward !== undefined && held.has(itemCountKey(q.reward))) vouched.add(questKey(q))
+    // a finished one (the `hasEveryItem` refusal, law 1). A tradeable reward never infers either
+    // (the header's gate).
+    if (q.reward === undefined || !isUntradeable(q.rewardStats)) continue
+    if (held.has(itemCountKey(q.reward))) vouched.add(questKey(q))
   }
   return vouched
 }
@@ -73,6 +96,15 @@ export function rewardInferredQuests(
  * hide-turned-in box, the class-unlock derivation, the Ready tab's first-time default) agrees
  * without consulting a second field. `logTurnIns` stays 0: the log's share is a fact about the
  * log, and this is not log evidence.
+ *
+ * THE COUNT IS max(ledger, 1), STATED AS WHAT IT IS: the best LOWER BOUND either witness can
+ * prove (reconcile.ts makes the same move for held counts, for the same reason). The inference
+ * and a ledger event cannot be told apart or added — the ledger's one recorded turn-in may BE
+ * the run that produced the held reward, or a different run — so a vouched quest whose ledger
+ * says 1 reads 1, not 2. The visible consequence, accepted: hand-recording "+1" on an inferred
+ * quest converts the derived floor into a stated event without moving the number (the badge's
+ * hover changes instead), and taking that statement back falls back to the floor rather than to
+ * zero — the reward is still in the bag, and the next read would honestly re-assert it.
  */
 export function withRewardInference(
   q: QuestProgress,

--- a/src/renderer/src/features/posky/useProgress.ts
+++ b/src/renderer/src/features/posky/useProgress.ts
@@ -28,6 +28,7 @@ import { ambiguousQuestNames, computeSharedItems, type SharedItemsMap } from './
 import { skyDroppersFor, type DropperMob } from './poskyDroppers'
 import { countTurnIns, newlyCompletedTurnIns } from './turnInCelebration'
 import { questDropRecency } from './questSort'
+import { rewardInferredQuests, withRewardInference } from './rewardInference'
 // The turn-in ledger (JOS-131) — the ONE place a turn-in count is decided, shared with main's
 // store so the renderer and the persisted file cannot disagree about what a count means.
 // Relative value import, per the repo's node-tested-module rule.
@@ -159,6 +160,14 @@ export interface QuestProgress {
   /** turned in at least once. Kept as the one-bit reading of `turnIns` for the surfaces that
    *  only need the badge (the Ignored list) and for sorts that predate the count. */
   completed: boolean
+  /**
+   * The count above was INFERRED from the reward item in the loaded inventory export (issue #27),
+   * not read from the log or stated by hand. Present only when that inference is the count's ONLY
+   * source — any ledger evidence wins and leaves this absent — so the UI can say where the
+   * reading came from and the undo control can say why there is nothing to take back
+   * (the classUnlocks.ts observed-vs-derived precedent). Derived on every read, never persisted.
+   */
+  rewardInferred?: true
   /**
    * epoch ms of the NEWEST drop among this quest's required items — the "most recent drop"
    * sort key. Absent when nothing it needs has ever dropped; recency is then unknown, not old.
@@ -630,12 +639,21 @@ export function useProgress(opts?: UseProgressOptions): UseProgress {
   })
 
   const overridesByKey = useMemo(() => itemOverridesByKey(itemOverrides), [itemOverrides])
+  // Which quests the loaded export vouches for (issue #27) — read from the RAW dump counts, not
+  // the reconciled `net`, because the inference is about what the export SAW, whatever count
+  // source the user picked for the farming numbers. Derived on every read, never persisted.
+  const rewardVouched = useMemo(
+    () => rewardInferredQuests(posky.quests, progress?.inventory),
+    [progress?.inventory]
+  )
   const quests = useMemo<QuestProgress[]>(() => {
     if (!progress) return []
     const counts = { all: turnIns.all, log: logCounts }
     const facts = { lastLootedAt, overrides: overridesByKey }
-    return posky.quests.map((q) => computeQuestProgress(q, net, counts, facts))
-  }, [progress, net, lastLootedAt, turnIns, logCounts, overridesByKey])
+    return posky.quests.map((q) =>
+      withRewardInference(computeQuestProgress(q, net, counts, facts), rewardVouched)
+    )
+  }, [progress, net, lastLootedAt, turnIns, logCounts, overridesByKey, rewardVouched])
 
   const classes = useMemo(() => [...new Set(posky.quests.map((q) => q.className))].sort(), [])
 

--- a/src/shared/questTurnIns.ts
+++ b/src/shared/questTurnIns.ts
@@ -30,6 +30,15 @@
 // completion is real but UNDATED, so it contributes a FLOOR OF ONE to the count and nothing else.
 // `completedQuests` keeps being written as the downgrade mirror (see shared/types.ts).
 //
+// AND ONE FLOOR THIS LEDGER DOES NOT SEE (issue #27): the Sky tab's DISPLAYED count is decided in
+// two stages. This module resolves the persisted + detected evidence; the renderer then floors a
+// quest at one when its untradeable reward sits in the loaded inventory export
+// (renderer/features/posky/rewardInference.ts), derived on every read and never written back
+// here. Two stated consequences: any OTHER consumer of this ledger reads the un-floored count and
+// may say "not turned in" where the Sky tab says "Turned in"; and the downgrade mirror never
+// contains an inferred completion, so an older build shows those quests un-done — both are the
+// price of keeping derived evidence out of the persisted record, paid on purpose.
+//
 // THERE IS NO "SINCE THE DUMP" COUNT ANY MORE (JOS-141). This file used to report a second count
 // — how many turn-ins landed after the loaded dump was generated — because JOS-128 made a dump
 // load RESET the held-count model, and a base of `dump + loot since the dump` already had every

--- a/tests/rewardInference.test.mts
+++ b/tests/rewardInference.test.mts
@@ -1,0 +1,172 @@
+// ============================================================================
+// Issue #27 — a quest whose REWARD is in the inventory export has been turned in.
+// ============================================================================
+//
+// THE REPORT (github issue #27, and reproduced on a second install): a fresh install loads an
+// inventory export, the export plainly contains a Sky quest's reward item, and the quest still
+// reads "not turned in". Nothing was broken — nothing ever consulted the reward. The ledger
+// (shared/questTurnIns.ts) has exactly three sources: log-detected trades, hand statements, and
+// the legacy `completedQuests` key. A turn-in done before logging was on leaves none of those.
+//
+// WHY THE INFERENCE IS SOUND, measured against the committed data (2026-08-16): every one of the
+// 95 Sky quests has a reward, every reward is UNIQUE to its quest, none appears as a drop
+// anywhere in the items DB, none is consumed by another Sky quest, and 92 of 94 in the DB are
+// NO DROP. Holding the reward proves at least one turn-in the same way a log line would.
+//
+// WHAT THIS SUITE PINS:
+//   1. THE SET (`rewardInferredQuests`): which quest keys the loaded export vouches for —
+//      matching on the same counting key the held counts use (lowercased, `+N` folded), so an
+//      exalted reward still testifies for its quest. A quest with no reward in the data never
+//      infers; an absent export infers nothing.
+//   2. THE FLOOR (`withRewardInference`): a vouched-for quest with NO other evidence reads
+//      turnIns 1 / completed, and says WHERE the reading came from (`rewardInferred`), because a
+//      reader who cannot tell "the log said so" from "we worked it out" cannot tell which rows
+//      to trust (the classUnlocks.ts precedent). Real evidence wins: any ledger count leaves the
+//      quest untouched and unlabelled.
+//   3. WHAT IT NEVER TOUCHES: the inference is DERIVED state — applied after
+//      `computeQuestProgress`, never written to the ledger — so consumption, the celebration
+//      baseline and persistence never see it. An inferred turn-in predates the log, so its items
+//      were never in the log counts and it owes no subtraction (the "a dump owes none" rule,
+//      one storey up).
+//   4. THE COMPOSITIONS: `everTurnedIn` reads an inferred quest as run, so the hide-turned-in
+//      box, the class-unlock derivation and the Ready tab's first-time default all get the same
+//      answer without reading a second field.
+//
+// ONE-DIRECTIONAL, deliberately: reward present ⇒ turned in; reward ABSENT proves nothing (the
+// export only covers what was open when it was written — a banked reward is invisible). Nothing
+// here ever un-completes a quest, which is the same promise "a dump adds, it never subtracts"
+// already makes about counts.
+//
+// Run: `npm test`.
+
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  rewardInferredQuests,
+  withRewardInference
+} from '../src/renderer/src/features/posky/rewardInference'
+import { everTurnedIn, firstTimeReady } from '../src/renderer/src/features/posky/questCompletion'
+import type { QuestProgress } from '../src/renderer/src/features/posky/useProgress'
+
+// =============================================================================
+// 1. The set: which quests the export vouches for
+// =============================================================================
+
+/** The three fields the inference reads; everything else on PoskyQuest is not its business. */
+const QUESTS = [
+  { className: 'Cleric', name: 'Cleric Test of Resolution', reward: 'Necklace of Resolution' },
+  { className: 'Wizard', name: 'Wizard Test of Focus', reward: "Al`Kabor's Cap of Binding" },
+  { className: 'Rogue', name: 'Rogue Test of Thievery', reward: 'Wispy Choker of Vigor' },
+  // The data has no quest without a reward today; the type allows one, so the rule must too.
+  { className: 'Monk', name: 'Monk Test of Stone', reward: undefined }
+]
+
+test('a reward sitting in the export vouches for its quest', () => {
+  const keys = rewardInferredQuests(QUESTS, { 'necklace of resolution': 1 })
+  assert.ok(keys.has('Cleric::Cleric Test of Resolution'))
+  assert.equal(keys.size, 1)
+})
+
+test('an exalted reward still testifies: the +N variant folds onto the counting key', () => {
+  // heldCountsFromDump keys are the RAW name lowercased — the fold is the inference's job.
+  const keys = rewardInferredQuests(QUESTS, { "al`kabor's cap of binding +2": 1 })
+  assert.ok(keys.has('Wizard::Wizard Test of Focus'))
+})
+
+test('a quest with no reward in the data never infers (missing data, not a finished quest)', () => {
+  const keys = rewardInferredQuests(QUESTS, { 'necklace of resolution': 1, undefined: 1 })
+  assert.ok(!keys.has('Monk::Monk Test of Stone'))
+})
+
+test('an absent reward proves nothing, and an absent export proves nothing about anything', () => {
+  assert.equal(rewardInferredQuests(QUESTS, { 'wispy choker of vigor': 1 }).size, 1)
+  assert.equal(rewardInferredQuests(QUESTS, {}).size, 0)
+  assert.equal(rewardInferredQuests(QUESTS, undefined).size, 0)
+})
+
+test('a zero or negative count is an absent item, not a held one', () => {
+  const keys = rewardInferredQuests(QUESTS, {
+    'necklace of resolution': 0,
+    'wispy choker of vigor': -1
+  })
+  assert.equal(keys.size, 0)
+})
+
+// =============================================================================
+// 2. The floor, and what real evidence does to it
+// =============================================================================
+
+/** A QuestProgress as a quest nobody has touched would carry it (the questRow precedent). */
+function questRow(p: { className: string; name: string; turnIns?: number }): QuestProgress {
+  const turnIns = p.turnIns ?? 0
+  return {
+    key: `${p.className}::${p.name}`,
+    className: p.className,
+    name: p.name,
+    items: [],
+    haveCount: 0,
+    needCount: 2,
+    ratio: 0,
+    missing: ['Wind Rune Ena', 'Pulsating Ruby'],
+    turnIns,
+    logTurnIns: 0,
+    completed: turnIns >= 1
+  }
+}
+
+const VOUCHED = new Set(['Cleric::Cleric Test of Resolution'])
+
+test('no other evidence + reward held → turnIns floors at 1, completed, and says why', () => {
+  const q = withRewardInference(questRow({ className: 'Cleric', name: 'Cleric Test of Resolution' }), VOUCHED)
+  assert.equal(q.turnIns, 1)
+  assert.equal(q.completed, true)
+  assert.equal(q.rewardInferred, true)
+  // The log's share is untouched: nothing here is log evidence.
+  assert.equal(q.logTurnIns, 0)
+})
+
+test('a quest the export does not vouch for is returned untouched and unlabelled', () => {
+  const before = questRow({ className: 'Rogue', name: 'Rogue Test of Thievery' })
+  const after = withRewardInference(before, VOUCHED)
+  assert.equal(after.turnIns, 0)
+  assert.equal(after.completed, false)
+  assert.equal(after.rewardInferred, undefined)
+})
+
+test('real evidence wins: a ledger count is never floored, relabelled or double-counted', () => {
+  const q = withRewardInference(
+    questRow({ className: 'Cleric', name: 'Cleric Test of Resolution', turnIns: 2 }),
+    VOUCHED
+  )
+  assert.equal(q.turnIns, 2)
+  assert.equal(q.rewardInferred, undefined)
+})
+
+test('the transform is pure: the input row is not mutated', () => {
+  const before = questRow({ className: 'Cleric', name: 'Cleric Test of Resolution' })
+  withRewardInference(before, VOUCHED)
+  assert.equal(before.turnIns, 0)
+  assert.equal(before.completed, false)
+  assert.equal((before as { rewardInferred?: true }).rewardInferred, undefined)
+})
+
+// =============================================================================
+// 3. The compositions: one field, every downstream reading agrees
+// =============================================================================
+
+test('everTurnedIn reads an inferred quest as run — hide-turned-in and class unlocks follow', () => {
+  const q = withRewardInference(questRow({ className: 'Cleric', name: 'Cleric Test of Resolution' }), VOUCHED)
+  assert.equal(everTurnedIn(q), true)
+})
+
+test('the Ready tab’s first-time default drops an inferred quest: it has been run', () => {
+  const inferred = withRewardInference(
+    questRow({ className: 'Cleric', name: 'Cleric Test of Resolution' }),
+    VOUCHED
+  )
+  const fresh = questRow({ className: 'Rogue', name: 'Rogue Test of Thievery' })
+  assert.deepEqual(
+    firstTimeReady([inferred, fresh]).map((q) => q.key),
+    ['Rogue::Rogue Test of Thievery']
+  )
+})

--- a/tests/rewardInference.test.mts
+++ b/tests/rewardInference.test.mts
@@ -52,13 +52,37 @@ import type { QuestProgress } from '../src/renderer/src/features/posky/useProgre
 // 1. The set: which quests the export vouches for
 // =============================================================================
 
-/** The three fields the inference reads; everything else on PoskyQuest is not its business. */
+/** The four fields the inference reads; everything else on PoskyQuest is not its business. */
 const QUESTS = [
-  { className: 'Cleric', name: 'Cleric Test of Resolution', reward: 'Necklace of Resolution' },
-  { className: 'Wizard', name: 'Wizard Test of Focus', reward: "Al`Kabor's Cap of Binding" },
-  { className: 'Rogue', name: 'Rogue Test of Thievery', reward: 'Wispy Choker of Vigor' },
+  {
+    className: 'Cleric',
+    name: 'Cleric Test of Resolution',
+    reward: 'Necklace of Resolution',
+    rewardStats: 'MAGIC ITEM LORE ITEM NO DROP\nSlot: NECK'
+  },
+  {
+    className: 'Wizard',
+    name: 'Wizard Test of Focus',
+    reward: "Al`Kabor's Cap of Binding",
+    rewardStats: 'MAGIC ITEM LORE ITEM NO DROP\nSlot: HEAD'
+  },
+  {
+    className: 'Rogue',
+    name: 'Rogue Test of Thievery',
+    reward: 'Wispy Choker of Vigor',
+    // The newer scrape shape spells it "No Trade" - both spellings are the same fact.
+    rewardStats: 'Lore Equipped, No Trade\nSlot: NECK'
+  },
+  // The two REAL tradeable rewards (the committed DB's only ones): no NO DROP, no No Trade.
+  // Holding one proves nothing - it can be bought or handed over - so it never vouches.
+  {
+    className: 'Necromancer',
+    name: 'Necromancer Test of Heart',
+    reward: 'Sphinx Heart Amulet',
+    rewardStats: 'MAGIC ITEM LORE ITEM\nSlot: NECK'
+  },
   // The data has no quest without a reward today; the type allows one, so the rule must too.
-  { className: 'Monk', name: 'Monk Test of Stone', reward: undefined }
+  { className: 'Monk', name: 'Monk Test of Stone', reward: undefined, rewardStats: undefined }
 ]
 
 test('a reward sitting in the export vouches for its quest', () => {
@@ -90,6 +114,23 @@ test('a zero or negative count is an absent item, not a held one', () => {
     'wispy choker of vigor': -1
   })
   assert.equal(keys.size, 0)
+})
+
+test('a TRADEABLE reward proves nothing: possession is only evidence when the item cannot move', () => {
+  // Sphinx Heart Amulet carries no NO DROP / No Trade - it can be bought or handed over, so
+  // holding it does not prove the quest was run. The other 92 rewards all state one of the two.
+  const keys = rewardInferredQuests(QUESTS, { 'sphinx heart amulet': 1 })
+  assert.equal(keys.size, 0)
+})
+
+test('both untradeable spellings vouch: the old scrape says NO DROP, the newer says No Trade', () => {
+  const keys = rewardInferredQuests(QUESTS, {
+    'necklace of resolution': 1,
+    'wispy choker of vigor': 1
+  })
+  assert.ok(keys.has('Cleric::Cleric Test of Resolution'))
+  assert.ok(keys.has('Rogue::Rogue Test of Thievery'))
+  assert.equal(keys.size, 2)
 })
 
 // =============================================================================


### PR DESCRIPTION
## Summary

Fixes #27. On a fresh install, a Plane of Sky quest the player had already completed read "not turned in" even when its reward item was sitting in the loaded inventory export. The turn-in ledger has three sources — log-detected trades, hand statements, and the legacy `completedQuests` key — and a turn-in done before `/log` was on leaves none of them behind. Nothing ever consulted the reward.

Now the reward is evidence. A quest whose reward appears in the export shows the "Turned in" badge, the hover says where the reading came from ("the reward for this quest is in your inventory export, and it cannot be obtained any other way"), and the undo control explains why there is nothing to take back — the same treatment log-detected counts already get.

## Why possession is proof

Measured against the committed data before writing any code: all 95 Sky quests have a reward, every reward is **unique to its quest**, none appears as a drop anywhere in the items DB, none is consumed as another Sky quest's required item, and 92 of the 94 present in the DB are NO DROP. Holding the reward proves at least one turn-in as surely as a log line would.

## Design

A derived, labelled floor of one turn-in (`rewardInference.ts`), on the `classUnlocks.ts` observed-vs-derived precedent and the legacy `completedQuests` floor ("a completion that is real but undated floors the count at 1"):

- **Applied after `computeQuestProgress`, never written to the ledger.** Consumption never sees it — an inferred turn-in predates the log, so its items were never in the log counts and it owes no subtraction (the "a dump owes none" rule, one storey up in `reconcile.ts`). The celebration baseline never sees it (no false toast on first load), and nothing is persisted (the export is re-read every time, so the reading cannot go stale in a store).
- **Labelled, and only when it is the count's only source.** Any ledger evidence wins and leaves the row exactly as the ledger said it; `rewardInferred` is absent on those rows.
- **One-directional.** Reward present ⇒ turned in; reward absent proves nothing — the export only covers what was open when it was written, and a banked reward is invisible (the repro character has two turned-in quests whose rewards the export never saw). Nothing here un-completes anything.
- **Matched on the counting key** (`itemCountKey`), so a reward the player has exalted to `+2` still testifies for its quest.

Because the floor lands on `turnIns` itself, every downstream reading — `everTurnedIn`, the hide-turned-in box, the class-unlock derivation, the Ready tab's first-time default — agrees without consulting a second field.

## Testing

- `tests/rewardInference.test.mts` — 11 plain-node tests, written first and watched fail: the vouching set (variant folding, backtick names, no-reward quests, absent exports, zero counts), the floor (real evidence wins, purity, `logTurnIns` untouched), and the compositions (`everTurnedIn`, `firstTimeReady`).
- Full unit suite green (4601 pass), typecheck and lint clean, all 7 sky e2e specs green (`sky-turnin`, `sky-inventory-autoload` included).
- Replayed end-to-end on a real fresh install matching the report: a 209-item export vouches for 14 quests; the 4 with no ledger evidence flip to completed, the 10 with ledger entries stay on their evidence. Confirmed live in the dev app.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Fable_5-D97757?logo=claude&logoColor=white)
