### PR TITLE
Sky: a Targets tab - the mobs you still need (fixes #30)

### DIFF
--- a/src/renderer/src/features/posky/DropperCell.tsx
+++ b/src/renderer/src/features/posky/DropperCell.tsx
@@ -50,8 +50,10 @@ function dropperRoster(droppers: readonly DropperMob[]): string {
 }
 
 /** One clickable mob name. `stopPropagation` matters where this sits inside a row that has its
- *  own click (the accordion summary) — opening a mob must never also toggle the panel. */
-function DropperName({
+ *  own click (the accordion summary) — opening a mob must never also toggle the panel. Exported
+ *  since the Targets tab (issue #30): a mob-major card names the same mobs the same way, and a
+ *  second copy of the click/keyboard handling would be a second thing to keep in step. */
+export function DropperName({
   mob,
   onOpenMob
 }: {

--- a/src/renderer/src/features/posky/IgnoredList.tsx
+++ b/src/renderer/src/features/posky/IgnoredList.tsx
@@ -55,7 +55,7 @@ export function IgnoredList({
               </Typography>
             )}
             <Box sx={{ flexGrow: 1 }} />
-            <TurnInBadge count={q.turnIns} />
+            <TurnInBadge count={q.turnIns} inferred={q.rewardInferred} />
           </Stack>
         ))}
       </Stack>

--- a/src/renderer/src/features/posky/PoskyView.tsx
+++ b/src/renderer/src/features/posky/PoskyView.tsx
@@ -7,6 +7,7 @@ import { IgnoredList } from './IgnoredList'
 import QuestFilterBar, { InventorySource } from './QuestFilterBar'
 import { countSourcePhrase } from '../inventory/countSource'
 import ClassUnlockList from './ClassUnlockList'
+import { TargetsView } from './TargetsView'
 import { useQuestList, type QuestListState, type TabKey } from './useQuestList'
 // The rows themselves live in their own file since JOS-389 — see its header for why.
 import { QuestList, type QuestAnchor, type QuestListProps } from './QuestList'
@@ -216,6 +217,15 @@ function PoskyTabs({ list, cleanupCount }: { list: QuestListState; cleanupCount:
         label={list.ready.length ? `Ready (${list.ready.length})` : 'Ready'}
         data-testid="posky-tab-ready"
       />
+      {/* "Targets" - who to pull next (issue #30). The COUNT is `list.targets.mobs.length`, the
+          same array the pane draws, on the Ready precedent above - the collective random-drop
+          entry and the no-known-source note are NOT in it, because the number answers "how many
+          mobs", not "how many sections". */}
+      <Tab
+        value="targets"
+        label={list.targets.mobs.length ? `Targets (${list.targets.mobs.length})` : 'Targets'}
+        data-testid="posky-tab-targets"
+      />
       {/* "Cleanup" - the owner's own word for the screen (JOS-389). The count is how many items
           the model lists, i.e. how many stacks are candidates to throw away, which is exactly the
           number that decides whether the tab is worth opening after a long campaign. */}
@@ -325,6 +335,12 @@ function PoskyBody(x: PoskyBodyProps): JSX.Element {
         inventoryLoadedAt={inventoryLoadedAt}
       />
     )
+  }
+  if (list.tab === 'targets') {
+    // The kill list (issue #30): derived from the same visible set as every other tab, drawn
+    // by its own view file (TargetsView.tsx) because it renders mob cards, not quest rows.
+    // `onOpenMob` rides in on the rows bundle — same router the quest rows' mob chips use.
+    return <TargetsView targets={list.targets} onOpenMob={rows.onOpenMob} />
   }
   if (list.tab === 'classes') {
     // The VISIBLE quests, like every other tab: a quest the user permanently ignored is not shown

--- a/src/renderer/src/features/posky/PoskyView.tsx
+++ b/src/renderer/src/features/posky/PoskyView.tsx
@@ -340,7 +340,17 @@ function PoskyBody(x: PoskyBodyProps): JSX.Element {
     // The kill list (issue #30): derived from the same visible set as every other tab, drawn
     // by its own view file (TargetsView.tsx) because it renders mob cards, not quest rows.
     // `onOpenMob` rides in on the rows bundle — same router the quest rows' mob chips use.
-    return <TargetsView targets={list.targets} onOpenMob={rows.onOpenMob} />
+    // The count source rides along on the Ready tab's JOS-294 argument - it decides every
+    // shortfall this tab shows.
+    return (
+      <TargetsView
+        targets={list.targets}
+        onOpenMob={rows.onOpenMob}
+        countSource={countSource}
+        onCountSource={onCountSource}
+        inventoryLoadedAt={inventoryLoadedAt}
+      />
+    )
   }
   if (list.tab === 'classes') {
     // The VISIBLE quests, like every other tab: a quest the user permanently ignored is not shown

--- a/src/renderer/src/features/posky/QuestAccordion.tsx
+++ b/src/renderer/src/features/posky/QuestAccordion.tsx
@@ -234,7 +234,7 @@ function QuestSummaryRow({
       {/* BOTH, since JOS-131. The turn-in badge is history ("you have done this, twice"); the
           chip beside it is the present ("and right now you are three items short of doing it
           again"). Collapsing them into one chip is what used to make a re-run invisible. */}
-      <TurnInBadge count={q.turnIns} />
+      <TurnInBadge count={q.turnIns} inferred={q.rewardInferred} />
       <Chip
         size="small"
         variant="outlined"

--- a/src/renderer/src/features/posky/TargetsView.tsx
+++ b/src/renderer/src/features/posky/TargetsView.tsx
@@ -14,13 +14,22 @@
 //
 // The names are the link, exactly as the Quests tab's dropper cells: `DropperName` is the same
 // component (exported from DropperCell.tsx rather than copied), so a mob card opens the same mob
-// page with the same catalog row a search hit would. No Popper anywhere (JOS-143); the only
-// hover is the native `title` a name already carries.
+// page with the same catalog row a search hit would. No Popper anywhere (JOS-143); the one hover
+// is a native `title` carrying the same `dropperFacts` roster line the Quests tab shows, so the
+// two tabs answer "who is this mob" with identical words.
+//
+// THE COUNT SOURCE RIDES THE PANE HEADER, above both states, on the Ready tab's JOS-294
+// argument: the source decides every shortfall on this tab (a rotated log under `log` reads
+// held 0 for everything and overstates the whole list), so the control that changes the
+// membership has to be visible where the membership is read - and reachable when it has
+// emptied the pane.
 
 import type { JSX } from 'react'
 import { Box, Chip, Stack, Typography } from '@mui/material'
-import { islandLabel } from './poskyDroppers'
+import type { CountSource } from '@shared/types'
+import { dropperFacts, islandLabel } from './poskyDroppers'
 import { DropperName } from './DropperCell'
+import { InventorySource } from './QuestFilterBar'
 import type { NeededItem, SkyTargetsModel, TargetMob } from './skyTargets'
 import type { MobTarget } from '../mobs/mobTarget'
 
@@ -60,7 +69,8 @@ function TargetRow({ target, onOpenMob }: { target: TargetMob; onOpenMob: (t: Mo
       sx={{ border: 1, borderColor: 'divider', borderRadius: 1, px: 2, py: 1.5 }}
     >
       <Stack direction="row" spacing={1} alignItems="center" sx={{ mb: 0.5 }}>
-        <Typography variant="subtitle2" component="span">
+        {/* The same facts roster the Quests tab's dropper cell hovers - an OS tooltip, no DOM. */}
+        <Typography variant="subtitle2" component="span" title={dropperFacts(target.mob)}>
           <DropperName mob={target.mob} onOpenMob={onOpenMob} />
         </Typography>
         {islands !== '' && (
@@ -112,19 +122,37 @@ function RemainderSection({
 export interface TargetsViewProps {
   targets: SkyTargetsModel
   onOpenMob: (t: MobTarget) => void
+  countSource: CountSource
+  onCountSource: (s: CountSource) => void
+  inventoryLoadedAt: number | null
 }
 
 /**
  * The pane. The count line reads the same `mobs` array the tab label counts, so the number on
  * the tab, the number up here and the rows below can never disagree. The empty state names the
  * rule that emptied it ("state, never process") - a fresh character sees a full list, a finished
- * one sees why there is nothing left.
+ * one sees why there is nothing left. The header row leaves `mb: 2.5` for the same reason
+ * ReadyList's does: the source caption is an overlay hanging off the dropdown's bottom edge.
  */
-export function TargetsView({ targets, onOpenMob }: TargetsViewProps): JSX.Element {
+export function TargetsView({
+  targets,
+  onOpenMob,
+  countSource,
+  onCountSource,
+  inventoryLoadedAt
+}: TargetsViewProps): JSX.Element {
   const n = targets.mobs.length
   const empty = n === 0 && targets.randomDrop.length === 0 && targets.unsourced.length === 0
   return (
     <Box data-testid="posky-targets" sx={{ flexGrow: 1, minHeight: 0, overflow: 'auto' }}>
+      <Stack direction="row" spacing={2} alignItems="center" useFlexGap sx={{ mb: 2.5 }}>
+        <Box sx={{ flexGrow: 1 }} />
+        <InventorySource
+          countSource={countSource}
+          onCountSource={onCountSource}
+          inventoryLoadedAt={inventoryLoadedAt}
+        />
+      </Stack>
       {empty ? (
         <Typography color="text.secondary">
           Nothing left to hunt - every quest you are tracking is turned in, ignored, or already
@@ -135,8 +163,7 @@ export function TargetsView({ targets, onOpenMob }: TargetsViewProps): JSX.Eleme
           <Typography variant="body2" color="text.secondary" data-testid="posky-targets-count">
             {n === 0
               ? 'No kill targets right now - what is left is below.'
-              : `${String(n)} mob${n === 1 ? '' : 's'} still worth killing. Mobs that close the most of what is left sort first.`}
-            {' Derived from your quest progress and the committed drop data - never a guess.'}
+              : `${String(n)} mob${n === 1 ? '' : 's'} still worth killing - the ones that close the most of what is left sort first.`}
           </Typography>
           {targets.mobs.map((t) => (
             <TargetRow key={t.mob.page} target={t} onOpenMob={onOpenMob} />

--- a/src/renderer/src/features/posky/TargetsView.tsx
+++ b/src/renderer/src/features/posky/TargetsView.tsx
@@ -1,0 +1,158 @@
+// TargetsView — the Targets tab (issue #30): every mob still worth killing, and why.
+//
+// The MODEL is skyTargets.ts (pure, node-tested); this file only draws it. Mob-major on purpose:
+// the Quests tab answers "what does this quest need" and players were inverting it in their heads
+// to the question they actually walk the islands with. Its own file on the ClassUnlockList
+// precedent - PoskyView is a container near its measured line ceiling, and a tab that draws its
+// own rows rather than quest accordions is a view of its own.
+//
+// THE ORDER OF THE PANE IS THE ORDER OF USEFULNESS (plan KTD): mob cards first - each one an
+// actionable pull - then the collective random-drop entry (the Wind Runes, which any Sky mob can
+// drop), then the no-known-source note, which is missing DATA stated out loud rather than hidden
+// (law 1). The mob order inside the first section is counted, not guessed: most still-needed
+// items covered first, ties by name (skyTargets.ts argues it).
+//
+// The names are the link, exactly as the Quests tab's dropper cells: `DropperName` is the same
+// component (exported from DropperCell.tsx rather than copied), so a mob card opens the same mob
+// page with the same catalog row a search hit would. No Popper anywhere (JOS-143); the only
+// hover is the native `title` a name already carries.
+
+import type { JSX } from 'react'
+import { Box, Chip, Stack, Typography } from '@mui/material'
+import { islandLabel } from './poskyDroppers'
+import { DropperName } from './DropperCell'
+import type { NeededItem, SkyTargetsModel, TargetMob } from './skyTargets'
+import type { MobTarget } from '../mobs/mobTarget'
+
+/** Selector-safe row handle: `sky-target-row-the-spiroc-lord`. */
+function rowSlug(page: string): string {
+  return page.replace(/[^a-z0-9]+/gi, '-').replace(/^-|-$/g, '').toLowerCase()
+}
+
+/**
+ * One still-needed item, as one line: how many are missing across every quest that wants it, and
+ * the quests by name. The count is the AGGREGATE shortfall (skyTargets.ts: summed need minus the
+ * uncapped held) - there is deliberately no per-quest split of the held copies, because any split
+ * would be invented semantics. A quest needing more than one says so beside its own name.
+ */
+function NeededItemLine({ item }: { item: NeededItem }): JSX.Element {
+  const quests = item.quests
+    .map((q) => (q.need > 1 ? `${q.questName} x${String(q.need)}` : q.questName))
+    .join(', ')
+  return (
+    <Typography variant="body2" data-testid="sky-target-item">
+      {item.shortfall}x <strong>{item.name}</strong>
+      <Typography component="span" variant="body2" color="text.secondary">
+        {' '}
+        - {quests}
+      </Typography>
+    </Typography>
+  )
+}
+
+/** One mob card: the clickable name, where its outstanding drops are, and what it still yields. */
+function TargetRow({ target, onOpenMob }: { target: TargetMob; onOpenMob: (t: MobTarget) => void }): JSX.Element {
+  const islands = islandLabel(target.islands)
+  return (
+    <Box
+      data-testid={`sky-target-row-${rowSlug(target.mob.page)}`}
+      data-covers={target.covers}
+      sx={{ border: 1, borderColor: 'divider', borderRadius: 1, px: 2, py: 1.5 }}
+    >
+      <Stack direction="row" spacing={1} alignItems="center" sx={{ mb: 0.5 }}>
+        <Typography variant="subtitle2" component="span">
+          <DropperName mob={target.mob} onOpenMob={onOpenMob} />
+        </Typography>
+        {islands !== '' && (
+          <Typography variant="caption" color="text.secondary">
+            {islands}
+          </Typography>
+        )}
+        <Box sx={{ flexGrow: 1 }} />
+        <Chip
+          size="small"
+          variant="outlined"
+          label={`${String(target.covers)} item${target.covers === 1 ? '' : 's'}`}
+        />
+      </Stack>
+      <Stack spacing={0.25}>
+        {target.items.map((it) => (
+          <NeededItemLine key={it.name} item={it} />
+        ))}
+      </Stack>
+    </Box>
+  )
+}
+
+/** The two honest remainders share one rendering: a titled list of the same item lines. */
+function RemainderSection({
+  title,
+  items,
+  testid
+}: {
+  title: string
+  items: readonly NeededItem[]
+  testid: string
+}): JSX.Element | null {
+  if (items.length === 0) return null
+  return (
+    <Box data-testid={testid} sx={{ border: 1, borderColor: 'divider', borderRadius: 1, px: 2, py: 1.5 }}>
+      <Typography variant="subtitle2" sx={{ mb: 0.5 }}>
+        {title}
+      </Typography>
+      <Stack spacing={0.25}>
+        {items.map((it) => (
+          <NeededItemLine key={it.name} item={it} />
+        ))}
+      </Stack>
+    </Box>
+  )
+}
+
+export interface TargetsViewProps {
+  targets: SkyTargetsModel
+  onOpenMob: (t: MobTarget) => void
+}
+
+/**
+ * The pane. The count line reads the same `mobs` array the tab label counts, so the number on
+ * the tab, the number up here and the rows below can never disagree. The empty state names the
+ * rule that emptied it ("state, never process") - a fresh character sees a full list, a finished
+ * one sees why there is nothing left.
+ */
+export function TargetsView({ targets, onOpenMob }: TargetsViewProps): JSX.Element {
+  const n = targets.mobs.length
+  const empty = n === 0 && targets.randomDrop.length === 0 && targets.unsourced.length === 0
+  return (
+    <Box data-testid="posky-targets" sx={{ flexGrow: 1, minHeight: 0, overflow: 'auto' }}>
+      {empty ? (
+        <Typography color="text.secondary">
+          Nothing left to hunt - every quest you are tracking is turned in, ignored, or already
+          has its items. A quest joins this list the moment it needs something again.
+        </Typography>
+      ) : (
+        <Stack spacing={1.5}>
+          <Typography variant="body2" color="text.secondary" data-testid="posky-targets-count">
+            {n === 0
+              ? 'No kill targets right now - what is left is below.'
+              : `${String(n)} mob${n === 1 ? '' : 's'} still worth killing. Mobs that close the most of what is left sort first.`}
+            {' Derived from your quest progress and the committed drop data - never a guess.'}
+          </Typography>
+          {targets.mobs.map((t) => (
+            <TargetRow key={t.mob.page} target={t} onOpenMob={onOpenMob} />
+          ))}
+          <RemainderSection
+            title="Random drops - any Plane of Sky mob can drop these"
+            items={targets.randomDrop}
+            testid="posky-targets-random"
+          />
+          <RemainderSection
+            title="No known source - the drop data does not say who carries these"
+            items={targets.unsourced}
+            testid="posky-targets-unsourced"
+          />
+        </Stack>
+      )}
+    </Box>
+  )
+}

--- a/src/renderer/src/features/posky/TurnInControls.tsx
+++ b/src/renderer/src/features/posky/TurnInControls.tsx
@@ -26,8 +26,20 @@ import type { QuestProgress } from './useProgress'
  * so would be noise on most of the list. The count appears from the second turn-in on
  * (`turnInBadgeLabel`), so the common case stays the plain "Turned in" it has always been.
  * `data-count` states the number a test can read without parsing the label.
+ *
+ * `inferred` is the issue-#27 reading — the count exists because the quest's REWARD is in the
+ * loaded inventory export, not because a turn-in was logged or stated — and the hover says so,
+ * because a reader who cannot tell "the log said so" from "we worked it out" cannot tell which
+ * rows to trust (classUnlocks.ts). `data-inferred` states it for a test the same way
+ * `data-count` states the number.
  */
-export function TurnInBadge({ count }: { count: number }): JSX.Element | null {
+export function TurnInBadge({
+  count,
+  inferred
+}: {
+  count: number
+  inferred?: boolean
+}): JSX.Element | null {
   if (count <= 0) return null
   return (
     <Chip
@@ -36,10 +48,13 @@ export function TurnInBadge({ count }: { count: number }): JSX.Element | null {
       variant="outlined"
       data-testid="posky-turned-in"
       data-count={count}
+      data-inferred={inferred ? 'true' : undefined}
       title={
-        count > 1
-          ? `Turned in ${String(count)} times. Each turn-in spends the items it required, so the progress beside this is what you hold toward doing it again.`
-          : 'Turned in once. The items it required were spent, so the progress beside this is what you hold toward doing it again.'
+        inferred
+          ? 'Turned in at least once: the reward for this quest is in your inventory export, and it cannot be obtained any other way.'
+          : count > 1
+            ? `Turned in ${String(count)} times. Each turn-in spends the items it required, so the progress beside this is what you hold toward doing it again.`
+            : 'Turned in once. The items it required were spent, so the progress beside this is what you hold toward doing it again.'
       }
       label={turnInBadgeLabel(count)}
     />
@@ -48,7 +63,9 @@ export function TurnInBadge({ count }: { count: number }): JSX.Element | null {
 
 /** The undo button, with the one thing it has to say for itself when it cannot act. */
 function UndoTurnIn({ q, onUndo }: { q: QuestProgress; onUndo: () => void }): JSX.Element {
-  const canUndo = q.turnIns > q.logTurnIns
+  // An INFERRED count (issue #27) cannot be taken back for the same reason a log-detected one
+  // cannot: the evidence (the reward in your export) would simply re-assert it on the next read.
+  const canUndo = !q.rewardInferred && q.turnIns > q.logTurnIns
   return (
     // The span outlives the tooltip that needed it, for the same reason: a DISABLED button
     // swallows no mouse events, and "why is this dead" is exactly the question the words answer.
@@ -56,9 +73,11 @@ function UndoTurnIn({ q, onUndo }: { q: QuestProgress; onUndo: () => void }): JS
       title={
         canUndo
           ? 'Take back the most recent turn-in you recorded by hand'
-          : q.turnIns === 0
-            ? 'Nothing to take back'
-            : 'This count comes from your log, so it cannot be taken back here'
+          : q.rewardInferred
+            ? 'This count comes from the reward in your inventory export, so it cannot be taken back here'
+            : q.turnIns === 0
+              ? 'Nothing to take back'
+              : 'This count comes from your log, so it cannot be taken back here'
       }
     >
       <IconButton size="small" data-testid="posky-undo-turnin" disabled={!canUndo} onClick={onUndo}>

--- a/src/renderer/src/features/posky/poskyDroppers.ts
+++ b/src/renderer/src/features/posky/poskyDroppers.ts
@@ -104,13 +104,30 @@ function toDropper(m: MobEntry): DropperMob {
 }
 
 /** Deterministic, source-order-independent: by name (case-folded), then page as the tiebreak.
- *  Nothing in the catalog ranks droppers, so inventing an importance order would be a guess. */
-function byName(a: DropperMob, b: DropperMob): number {
+ *  Nothing in the catalog ranks droppers, so inventing an importance order would be a guess.
+ *  EXPORTED since the Targets tab (issue #30): its cross-quest fold sorts the same mobs, and two
+ *  comparators for one order is exactly the drift that would make two tabs name different lead
+ *  mobs from identical data. */
+export function dropperNameOrder(a: DropperMob, b: DropperMob): number {
   const an = a.name.toLowerCase()
   const bn = b.name.toLowerCase()
   if (an !== bn) return an < bn ? -1 : 1
   return a.page < b.page ? -1 : a.page > b.page ? 1 : 0
 }
+
+/**
+ * Is this `who` the scrape's "random drop — any Plane of Sky mob" statement? A case-insensitive
+ * PREFIX match on purpose, in the module that owns the `who` vocabulary (the header's nine
+ * measured values): the literal sentinel carries an em dash, which `tests/copyNoEmDash.test.mts`
+ * bans from renderer string literals — and consumers matching prose they do not own is how a
+ * scraper rewording silently reclassifies every Wind Rune. One predicate, beside the vocabulary
+ * it interprets, is the closest this can get to the string's author without touching scripts/.
+ */
+export function isRandomDropWho(who: readonly string[]): boolean {
+  return who.some((w) => w.toLowerCase().startsWith('random drop'))
+}
+
+const byName = dropperNameOrder
 
 /**
  * Invert a mob list into item -> droppers.

--- a/src/renderer/src/features/posky/rewardInference.ts
+++ b/src/renderer/src/features/posky/rewardInference.ts
@@ -1,0 +1,83 @@
+// ============================================================================
+// rewardInference.ts — the reward item in your inventory export IS evidence (issue #27).
+// ============================================================================
+//
+// THE REPORT: a fresh install loads an inventory export that plainly contains a Sky quest's
+// reward, and the quest still reads "not turned in". Nothing was broken — nothing ever consulted
+// the reward. The ledger (shared/questTurnIns.ts) has three sources: log-detected trades, hand
+// statements, and the legacy `completedQuests` key. A turn-in done before logging was on leaves
+// none of those, and rotating a log un-completes history the same way.
+//
+// WHY POSSESSION IS PROOF, measured against the committed data (2026-08-16): all 95 Sky quests
+// have a reward, every reward is UNIQUE to its quest, none appears as a drop anywhere in the
+// items DB, none is consumed as another Sky quest's required item, and 92 of the 94 in the DB
+// are NO DROP. The rewards cannot be obtained without doing the quest, so holding one proves at
+// least one turn-in as surely as a log line would.
+//
+// WHAT THE INFERENCE IS — a DERIVED floor of one, in the classUnlocks.ts mold (observed wins,
+// derived is labelled) and on the legacy `completedQuests` precedent (a completion that is real
+// but undated floors the count at 1 and says nothing else):
+//   * applied AFTER `computeQuestProgress`, never written to the ledger. Consumption never sees
+//     it (an inferred turn-in predates the log, so its items were never in the log counts and it
+//     owes no subtraction — the "a dump owes none" rule, reconcile.ts), the celebration baseline
+//     never sees it (no false toast on first load), and nothing is persisted (the export is
+//     re-read every time, so the reading can never go stale in a store);
+//   * LABELLED (`rewardInferred`), and only present when it is the count's ONLY source — any
+//     ledger evidence wins and leaves the row exactly as the ledger said it;
+//   * ONE-DIRECTIONAL. Reward present ⇒ turned in; reward ABSENT proves nothing, because the
+//     export only covers what was open when it was written (a banked reward is invisible — the
+//     owner's own store has two turned-in quests whose rewards the export never saw). Nothing
+//     here un-completes anything, which is the promise "a dump adds, it never subtracts"
+//     already makes about counts.
+//
+// The match is on the COUNTING key (`itemCountKey`: lowercased, ` +N` folded), because the
+// export's keys are raw names lowercased (heldCountsFromDump) and a reward the player has
+// exalted to `+2` is still the quest's reward.
+
+import type { PoskyQuest } from '@shared/types'
+import { itemCountKey } from '../../lib/itemName'
+import { questKey } from './keys'
+import type { QuestProgress } from './useProgress'
+
+/**
+ * Which quests the loaded export vouches for: every quest whose reward item the inventory holds.
+ *
+ * `inventory` is `ProgressState.inventory` as stored — raw names lowercased, `+N` variants NOT
+ * yet folded — so the fold happens here, on both sides of the match. A count of zero or less is
+ * an absent item: the parser never writes one, so it can only mean a hand-edited store, and an
+ * item you hold none of vouches for nothing.
+ */
+export function rewardInferredQuests(
+  quests: readonly Pick<PoskyQuest, 'className' | 'name' | 'reward'>[],
+  inventory: Record<string, number> | undefined
+): Set<string> {
+  const vouched = new Set<string>()
+  if (!inventory) return vouched
+  const held = new Set<string>()
+  for (const [name, count] of Object.entries(inventory)) {
+    if (count > 0) held.add(itemCountKey(name))
+  }
+  for (const q of quests) {
+    // A quest with no reward in the data never infers: that is missing data about a quest, not
+    // a finished one (the `hasEveryItem` refusal, law 1).
+    if (q.reward !== undefined && held.has(itemCountKey(q.reward))) vouched.add(questKey(q))
+  }
+  return vouched
+}
+
+/**
+ * The floor: a vouched-for quest with NO other evidence reads turnIns 1 / completed, labelled.
+ *
+ * Applied per row after `computeQuestProgress`, the way `firstTimeReady` narrows `readyQuests` —
+ * a composition, not a rewrite — so every downstream reading of `turnIns` (`everTurnedIn`, the
+ * hide-turned-in box, the class-unlock derivation, the Ready tab's first-time default) agrees
+ * without consulting a second field. `logTurnIns` stays 0: the log's share is a fact about the
+ * log, and this is not log evidence.
+ */
+export function withRewardInference(
+  q: QuestProgress,
+  vouched: ReadonlySet<string>
+): QuestProgress {
+  if (q.turnIns > 0 || !vouched.has(q.key)) return q
+  return { ...q, turnIns: 1, completed: true, rewardInferred: true }
+}

--- a/src/renderer/src/features/posky/rewardInference.ts
+++ b/src/renderer/src/features/posky/rewardInference.ts
@@ -11,8 +11,17 @@
 // WHY POSSESSION IS PROOF, measured against the committed data (2026-08-16): all 95 Sky quests
 // have a reward, every reward is UNIQUE to its quest, none appears as a drop anywhere in the
 // items DB, none is consumed as another Sky quest's required item, and 92 of the 94 in the DB
-// are NO DROP. The rewards cannot be obtained without doing the quest, so holding one proves at
-// least one turn-in as surely as a log line would.
+// are NO DROP or No Trade. For THOSE, holding the reward proves at least one turn-in as surely
+// as a log line would - an item that cannot move has exactly one way into a bag.
+//
+// THE TWO THAT CAN MOVE PROVE NOTHING, and the gate below is that sentence as code. Bloody
+// Griffon-Hide Wrist Guard and Sphinx Heart Amulet (both Necromancer rewards) carry no
+// NO DROP / No Trade flag: they can be bought or handed over, so possession is not evidence and
+// inferring from it would mark a quest done that never ran - with the undo control honestly
+// disabled, leaving no way to say otherwise. So the inference fires only when the reward's own
+// stat blob states it cannot be traded, in either spelling the scrape uses ("NO DROP" on the
+// classic pages, "Lore Equipped, No Trade" on the newer ones). Those two quests simply never
+// infer, which is the status quo they had before this module existed.
 //
 // WHAT THE INFERENCE IS — a DERIVED floor of one, in the classUnlocks.ts mold (observed wins,
 // derived is labelled) and on the legacy `completedQuests` precedent (a completion that is real
@@ -40,7 +49,19 @@ import { questKey } from './keys'
 import type { QuestProgress } from './useProgress'
 
 /**
- * Which quests the loaded export vouches for: every quest whose reward item the inventory holds.
+ * Does the reward's own stat blob say it cannot be traded? Both spellings the scrape carries:
+ * "NO DROP" (the classic wiki pages) and "No Trade" (the newer ones, sometimes "LORE ITEM NO
+ * TRADE"). An ABSENT or silent blob reads as tradeable - the conservative side of the gate,
+ * because the failure modes are asymmetric: not inferring costs a badge the user can still
+ * record by hand, while inferring falsely marks a quest done with the undo honestly disabled.
+ */
+function isUntradeable(rewardStats: string | undefined): boolean {
+  return /no[ -]?(drop|trade)/i.test(rewardStats ?? '')
+}
+
+/**
+ * Which quests the loaded export vouches for: every quest whose UNTRADEABLE reward item the
+ * inventory holds (the header's gate - a reward that can move proves nothing).
  *
  * `inventory` is `ProgressState.inventory` as stored — raw names lowercased, `+N` variants NOT
  * yet folded — so the fold happens here, on both sides of the match. A count of zero or less is
@@ -48,7 +69,7 @@ import type { QuestProgress } from './useProgress'
  * item you hold none of vouches for nothing.
  */
 export function rewardInferredQuests(
-  quests: readonly Pick<PoskyQuest, 'className' | 'name' | 'reward'>[],
+  quests: readonly Pick<PoskyQuest, 'className' | 'name' | 'reward' | 'rewardStats'>[],
   inventory: Record<string, number> | undefined
 ): Set<string> {
   const vouched = new Set<string>()
@@ -59,8 +80,10 @@ export function rewardInferredQuests(
   }
   for (const q of quests) {
     // A quest with no reward in the data never infers: that is missing data about a quest, not
-    // a finished one (the `hasEveryItem` refusal, law 1).
-    if (q.reward !== undefined && held.has(itemCountKey(q.reward))) vouched.add(questKey(q))
+    // a finished one (the `hasEveryItem` refusal, law 1). A tradeable reward never infers either
+    // (the header's gate).
+    if (q.reward === undefined || !isUntradeable(q.rewardStats)) continue
+    if (held.has(itemCountKey(q.reward))) vouched.add(questKey(q))
   }
   return vouched
 }
@@ -73,6 +96,15 @@ export function rewardInferredQuests(
  * hide-turned-in box, the class-unlock derivation, the Ready tab's first-time default) agrees
  * without consulting a second field. `logTurnIns` stays 0: the log's share is a fact about the
  * log, and this is not log evidence.
+ *
+ * THE COUNT IS max(ledger, 1), STATED AS WHAT IT IS: the best LOWER BOUND either witness can
+ * prove (reconcile.ts makes the same move for held counts, for the same reason). The inference
+ * and a ledger event cannot be told apart or added — the ledger's one recorded turn-in may BE
+ * the run that produced the held reward, or a different run — so a vouched quest whose ledger
+ * says 1 reads 1, not 2. The visible consequence, accepted: hand-recording "+1" on an inferred
+ * quest converts the derived floor into a stated event without moving the number (the badge's
+ * hover changes instead), and taking that statement back falls back to the floor rather than to
+ * zero — the reward is still in the bag, and the next read would honestly re-assert it.
  */
 export function withRewardInference(
   q: QuestProgress,

--- a/src/renderer/src/features/posky/skyTargets.ts
+++ b/src/renderer/src/features/posky/skyTargets.ts
@@ -114,66 +114,80 @@ function isRandomDrop(who: readonly string[]): boolean {
   return who.some((w) => w.toLowerCase().startsWith('random drop'))
 }
 
-/** The Targets model, from the quests the user can see. Membership is the fold, nothing else. */
-export function skyTargets(quests: readonly TargetsQuest[]): SkyTargetsModel {
+/** Fold one quest item into its counting key's aggregate. */
+function recordItem(byKey: Map<string, ItemAgg>, q: TargetsQuest, it: TargetsQuestItem): void {
+  const key = itemCountKey(it.name)
+  const agg = byKey.get(key) ?? {
+    name: it.name,
+    totalNeed: 0,
+    held: it.held,
+    droppers: it.droppers,
+    who: it.who,
+    islands: new Set<string>(),
+    quests: []
+  }
+  agg.totalNeed += it.need
+  // Prefer the BASE display name over a `+N` variant, the deriveLootNames rule.
+  if (agg.name !== normalizeItemName(agg.name) && it.name === normalizeItemName(it.name)) {
+    agg.name = it.name
+  }
+  // Same counting key ⇒ same resolved droppers; keep the first non-empty answer.
+  if (agg.droppers.length === 0 && it.droppers.length > 0) agg.droppers = it.droppers
+  const island = islandOf(it.where)
+  if (island !== undefined) agg.islands.add(island)
+  agg.quests.push({ className: q.className, questName: q.name, need: it.need })
+  byKey.set(key, agg)
+}
+
+/** Everything the need set says, per counting key. The never-turned-in filter is HERE. */
+function accumulateNeeds(quests: readonly TargetsQuest[]): Map<string, ItemAgg> {
   const byKey = new Map<string, ItemAgg>()
   for (const q of quests) {
     if (everTurnedIn(q)) continue
-    for (const it of q.items) {
-      const key = itemCountKey(it.name)
-      const agg = byKey.get(key) ?? {
-        name: it.name,
-        totalNeed: 0,
-        held: it.held,
-        droppers: it.droppers,
-        who: it.who,
-        islands: new Set<string>(),
-        quests: []
-      }
-      agg.totalNeed += it.need
-      // Prefer the BASE display name over a `+N` variant, the deriveLootNames rule.
-      if (agg.name !== normalizeItemName(agg.name) && it.name === normalizeItemName(it.name)) {
-        agg.name = it.name
-      }
-      // Same counting key ⇒ same resolved droppers; keep the first non-empty answer.
-      if (agg.droppers.length === 0 && it.droppers.length > 0) agg.droppers = it.droppers
-      const island = islandOf(it.where)
-      if (island !== undefined) agg.islands.add(island)
-      agg.quests.push({ className: q.className, questName: q.name, need: it.need })
-      byKey.set(key, agg)
-    }
+    for (const it of q.items) recordItem(byKey, q, it)
   }
+  return byKey
+}
 
-  const mobsByPage = new Map<string, { mob: DropperMob; islands: Set<string>; items: NeededItem[] }>()
+/** One aggregate as the pane's item line — or nothing, when the holdings already cover it. */
+function toNeeded(agg: ItemAgg): NeededItem | null {
+  const shortfall = Math.max(0, agg.totalNeed - agg.held)
+  if (shortfall === 0) return null
+  return { name: agg.name, shortfall, quests: agg.quests, islands: sortIslands(agg.islands) }
+}
+
+interface MobAcc {
+  mob: DropperMob
+  islands: Set<string>
+  items: NeededItem[]
+}
+
+/** Fold one needed item onto every mob that drops it — per ITEM dedupe by page, so a page listed
+ *  twice on one item cannot inflate its coverage (the questKillTargets rule). */
+function foldIntoMobs(mobsByPage: Map<string, MobAcc>, needed: NeededItem, droppers: readonly DropperMob[]): void {
+  const seen = new Set<string>()
+  for (const m of droppers) {
+    if (seen.has(m.page)) continue
+    seen.add(m.page)
+    const hit = mobsByPage.get(m.page) ?? { mob: m, islands: new Set<string>(), items: [] }
+    hit.items.push(needed)
+    for (const island of needed.islands) hit.islands.add(island)
+    mobsByPage.set(m.page, hit)
+  }
+}
+
+/** The Targets model, from the quests the user can see. Membership is the fold, nothing else. */
+export function skyTargets(quests: readonly TargetsQuest[]): SkyTargetsModel {
+  const mobsByPage = new Map<string, MobAcc>()
   const randomDrop: NeededItem[] = []
   const unsourced: NeededItem[] = []
-  for (const agg of byKey.values()) {
-    const shortfall = Math.max(0, agg.totalNeed - agg.held)
-    if (shortfall === 0) continue
-    const needed: NeededItem = {
-      name: agg.name,
-      shortfall,
-      quests: agg.quests,
-      islands: sortIslands(agg.islands)
-    }
-    if (agg.droppers.length > 0) {
-      // Per ITEM, so a page listed twice on one item cannot inflate its coverage.
-      const seen = new Set<string>()
-      for (const m of agg.droppers) {
-        if (seen.has(m.page)) continue
-        seen.add(m.page)
-        const hit = mobsByPage.get(m.page) ?? { mob: m, islands: new Set<string>(), items: [] }
-        hit.items.push(needed)
-        for (const island of needed.islands) hit.islands.add(island)
-        mobsByPage.set(m.page, hit)
-      }
-    } else if (isRandomDrop(agg.who)) {
-      randomDrop.push(needed)
-    } else {
-      unsourced.push(needed)
-    }
+  for (const agg of accumulateNeeds(quests).values()) {
+    const needed = toNeeded(agg)
+    if (needed === null) continue
+    if (agg.droppers.length > 0) foldIntoMobs(mobsByPage, needed, agg.droppers)
+    else if (isRandomDrop(agg.who)) randomDrop.push(needed)
+    else unsourced.push(needed)
   }
-
   const mobs: TargetMob[] = [...mobsByPage.values()]
     .map((e) => ({
       mob: e.mob,

--- a/src/renderer/src/features/posky/skyTargets.ts
+++ b/src/renderer/src/features/posky/skyTargets.ts
@@ -38,7 +38,13 @@
 
 import { itemCountKey, normalizeItemName } from '../../lib/itemName'
 import { everTurnedIn } from './questCompletion'
-import { islandNumber, islandOf, type DropperMob } from './poskyDroppers'
+import {
+  dropperNameOrder,
+  isRandomDropWho,
+  islandNumber,
+  islandOf,
+  type DropperMob
+} from './poskyDroppers'
 
 /** One quest item as the fold reads it — the `ItemProgress` fields it consumes, structural. */
 export interface TargetsQuestItem {
@@ -92,27 +98,22 @@ interface ItemAgg {
   totalNeed: number
   held: number
   droppers: readonly DropperMob[]
-  who: readonly string[]
+  /** true the moment ANY contributing quest's `who` states the random-drop sentinel — a flag
+   *  rather than a frozen `who` array, so classification can never depend on fold order. */
+  isRandom: boolean
   islands: Set<string>
   quests: { className: string; questName: string; need: number }[]
 }
 
+/** Item lines and both remainder lists read alphabetically — local to this pane, no counterpart
+ *  elsewhere to drift from. Mob order is `dropperNameOrder`, the one comparator the Quests tab's
+ *  own kill targets use, imported rather than copied so the two tabs can never disagree about
+ *  which mob leads a tie. */
 const byItemName = (a: NeededItem, b: NeededItem): number =>
   a.name.toLowerCase().localeCompare(b.name.toLowerCase())
 
-const byMobName = (a: TargetMob, b: TargetMob): number => {
-  const an = a.mob.name.toLowerCase()
-  const bn = b.mob.name.toLowerCase()
-  return an === bn ? a.mob.page.localeCompare(b.mob.page) : an.localeCompare(bn)
-}
-
 const sortIslands = (islands: Set<string>): string[] =>
   [...islands].sort((a, b) => islandNumber(a) - islandNumber(b))
-
-/** Is this `who` the scrape's random-drop statement? Prefix match — see the header. */
-function isRandomDrop(who: readonly string[]): boolean {
-  return who.some((w) => w.toLowerCase().startsWith('random drop'))
-}
 
 /** Fold one quest item into its counting key's aggregate. */
 function recordItem(byKey: Map<string, ItemAgg>, q: TargetsQuest, it: TargetsQuestItem): void {
@@ -122,11 +123,12 @@ function recordItem(byKey: Map<string, ItemAgg>, q: TargetsQuest, it: TargetsQue
     totalNeed: 0,
     held: it.held,
     droppers: it.droppers,
-    who: it.who,
+    isRandom: false,
     islands: new Set<string>(),
     quests: []
   }
   agg.totalNeed += it.need
+  agg.isRandom = agg.isRandom || isRandomDropWho(it.who)
   // Prefer the BASE display name over a `+N` variant, the deriveLootNames rule.
   if (agg.name !== normalizeItemName(agg.name) && it.name === normalizeItemName(it.name)) {
     agg.name = it.name
@@ -185,7 +187,7 @@ export function skyTargets(quests: readonly TargetsQuest[]): SkyTargetsModel {
     const needed = toNeeded(agg)
     if (needed === null) continue
     if (agg.droppers.length > 0) foldIntoMobs(mobsByPage, needed, agg.droppers)
-    else if (isRandomDrop(agg.who)) randomDrop.push(needed)
+    else if (agg.isRandom) randomDrop.push(needed)
     else unsourced.push(needed)
   }
   const mobs: TargetMob[] = [...mobsByPage.values()]
@@ -195,7 +197,7 @@ export function skyTargets(quests: readonly TargetsQuest[]): SkyTargetsModel {
       islands: sortIslands(e.islands),
       items: [...e.items].sort(byItemName)
     }))
-    .sort((a, b) => (a.covers === b.covers ? byMobName(a, b) : b.covers - a.covers))
+    .sort((a, b) => (a.covers === b.covers ? dropperNameOrder(a.mob, b.mob) : b.covers - a.covers))
   randomDrop.sort(byItemName)
   unsourced.sort(byItemName)
   return { mobs, randomDrop, unsourced }

--- a/src/renderer/src/features/posky/skyTargets.ts
+++ b/src/renderer/src/features/posky/skyTargets.ts
@@ -1,0 +1,188 @@
+// ============================================================================
+// skyTargets.ts — the Targets tab's whole model: "who do I still kill", cross-quest.
+// ============================================================================
+//
+// Issue #30. The tracker says what each quest needs; the player's real question on the islands
+// is the inversion — which mobs are still worth pulling, across every quest at once. This module
+// is that inversion as a pure fold: no React, no data bundle, relative value imports, pinned by
+// tests/skyTargets.test.mts (half against the committed catalog, the poskyDroppers precedent).
+//
+// THE NEED SET is never-turned-in and nothing else (`everTurnedIn` — the Ready tab's first-time
+// reading). A reward-inferred completion reads turnIns >= 1 through the same predicate, so the
+// inference needs no special case here. The CALLER supplies the visible (not-ignored) quest set;
+// ignoring is the one flag that means "never show me this", and it is decided upstream in
+// useQuestList exactly once — this module does not re-filter (the Ready tab's rule).
+//
+// SHORTFALL AGGREGATES PER COUNTING KEY, NEVER PER QUEST. `computeQuestProgress` clamps `have`
+// per quest and allocates nothing across quests, so a per-quest `have < need` filter would read
+// two quests each "satisfied" by the same single held copy — and Sky quests contend for items
+// heavily (sharedItems.ts). The rule: totalNeed summed over the need set, minus the UNCAPPED
+// `held` (same counting key ⇒ same held number on every occurrence), floored at zero. There is
+// deliberately NO per-quest allocation of the held copies — any split (first-wins, proportional)
+// would be invented semantics; the aggregate is the only number the data can vouch for, so the
+// aggregate is the only number shown.
+//
+// CLASSIFICATION IS THE SCRAPE'S OWN WORDS (law 1, never a guess):
+//   * resolved `droppers` fold into mob cards — dedupe by `page` per item so a twice-listed
+//     mob cannot inflate its coverage (the questKillTargets rule, cross-quest);
+//   * an unresolved item whose `who` starts with "random drop" (case-insensitive PREFIX — the
+//     literal sentinel carries an em dash, and copyNoEmDash.test.mts rejects that character in
+//     any src/renderer string literal) is the collective random-drop entry;
+//   * anything else unresolved goes to the no-known-source list — shown as missing data, never
+//     dropped and never guessed at.
+//
+// THE ORDER IS COUNTED, NOT GUESSED: mobs by distinct needed items covered, descending, then
+// name — killing the top row closes the most of what is left. Items inside a card and both
+// special lists read alphabetically: deterministic, explainable, nothing invented. Islands ride
+// per mob from the items that mob is the target for, in island-number order.
+
+import { itemCountKey, normalizeItemName } from '../../lib/itemName'
+import { everTurnedIn } from './questCompletion'
+import { islandNumber, islandOf, type DropperMob } from './poskyDroppers'
+
+/** One quest item as the fold reads it — the `ItemProgress` fields it consumes, structural. */
+export interface TargetsQuestItem {
+  name: string
+  need: number
+  /** UNCAPPED held count (`ItemProgress.held`) — the per-quest clamped `have` is never read. */
+  held: number
+  droppers: readonly DropperMob[]
+  where: string
+  who: readonly string[]
+}
+
+/** One quest as the fold reads it — `QuestProgress`, structurally. */
+export interface TargetsQuest {
+  className: string
+  name: string
+  turnIns: number
+  items: readonly TargetsQuestItem[]
+}
+
+/** One still-needed item: the aggregate shortfall and every need-set quest that wants it. */
+export interface NeededItem {
+  name: string
+  /** summed required count across the need set, minus held, floored at zero — always > 0 here */
+  shortfall: number
+  quests: { className: string; questName: string; need: number }[]
+  /** where it drops, island-number order; empty when posky states no island */
+  islands: string[]
+}
+
+/** One mob still worth killing, with everything it can still yield. */
+export interface TargetMob {
+  mob: DropperMob
+  /** distinct needed items this mob drops — the sort key, always `items.length` */
+  covers: number
+  islands: string[]
+  items: NeededItem[]
+}
+
+export interface SkyTargetsModel {
+  mobs: TargetMob[]
+  /** needed items with no kill target that posky calls a random drop (the Wind Runes) */
+  randomDrop: NeededItem[]
+  /** needed items nothing committed can source — missing data, stated rather than hidden */
+  unsourced: NeededItem[]
+}
+
+/** Per counting key, everything the need set says about one item, accumulated before deciding. */
+interface ItemAgg {
+  name: string
+  totalNeed: number
+  held: number
+  droppers: readonly DropperMob[]
+  who: readonly string[]
+  islands: Set<string>
+  quests: { className: string; questName: string; need: number }[]
+}
+
+const byItemName = (a: NeededItem, b: NeededItem): number =>
+  a.name.toLowerCase().localeCompare(b.name.toLowerCase())
+
+const byMobName = (a: TargetMob, b: TargetMob): number => {
+  const an = a.mob.name.toLowerCase()
+  const bn = b.mob.name.toLowerCase()
+  return an === bn ? a.mob.page.localeCompare(b.mob.page) : an.localeCompare(bn)
+}
+
+const sortIslands = (islands: Set<string>): string[] =>
+  [...islands].sort((a, b) => islandNumber(a) - islandNumber(b))
+
+/** Is this `who` the scrape's random-drop statement? Prefix match — see the header. */
+function isRandomDrop(who: readonly string[]): boolean {
+  return who.some((w) => w.toLowerCase().startsWith('random drop'))
+}
+
+/** The Targets model, from the quests the user can see. Membership is the fold, nothing else. */
+export function skyTargets(quests: readonly TargetsQuest[]): SkyTargetsModel {
+  const byKey = new Map<string, ItemAgg>()
+  for (const q of quests) {
+    if (everTurnedIn(q)) continue
+    for (const it of q.items) {
+      const key = itemCountKey(it.name)
+      const agg = byKey.get(key) ?? {
+        name: it.name,
+        totalNeed: 0,
+        held: it.held,
+        droppers: it.droppers,
+        who: it.who,
+        islands: new Set<string>(),
+        quests: []
+      }
+      agg.totalNeed += it.need
+      // Prefer the BASE display name over a `+N` variant, the deriveLootNames rule.
+      if (agg.name !== normalizeItemName(agg.name) && it.name === normalizeItemName(it.name)) {
+        agg.name = it.name
+      }
+      // Same counting key ⇒ same resolved droppers; keep the first non-empty answer.
+      if (agg.droppers.length === 0 && it.droppers.length > 0) agg.droppers = it.droppers
+      const island = islandOf(it.where)
+      if (island !== undefined) agg.islands.add(island)
+      agg.quests.push({ className: q.className, questName: q.name, need: it.need })
+      byKey.set(key, agg)
+    }
+  }
+
+  const mobsByPage = new Map<string, { mob: DropperMob; islands: Set<string>; items: NeededItem[] }>()
+  const randomDrop: NeededItem[] = []
+  const unsourced: NeededItem[] = []
+  for (const agg of byKey.values()) {
+    const shortfall = Math.max(0, agg.totalNeed - agg.held)
+    if (shortfall === 0) continue
+    const needed: NeededItem = {
+      name: agg.name,
+      shortfall,
+      quests: agg.quests,
+      islands: sortIslands(agg.islands)
+    }
+    if (agg.droppers.length > 0) {
+      // Per ITEM, so a page listed twice on one item cannot inflate its coverage.
+      const seen = new Set<string>()
+      for (const m of agg.droppers) {
+        if (seen.has(m.page)) continue
+        seen.add(m.page)
+        const hit = mobsByPage.get(m.page) ?? { mob: m, islands: new Set<string>(), items: [] }
+        hit.items.push(needed)
+        for (const island of needed.islands) hit.islands.add(island)
+        mobsByPage.set(m.page, hit)
+      }
+    } else if (isRandomDrop(agg.who)) {
+      randomDrop.push(needed)
+    } else {
+      unsourced.push(needed)
+    }
+  }
+
+  const mobs: TargetMob[] = [...mobsByPage.values()]
+    .map((e) => ({
+      mob: e.mob,
+      covers: e.items.length,
+      islands: sortIslands(e.islands),
+      items: [...e.items].sort(byItemName)
+    }))
+    .sort((a, b) => (a.covers === b.covers ? byMobName(a, b) : b.covers - a.covers))
+  randomDrop.sort(byItemName)
+  unsourced.sort(byItemName)
+  return { mobs, randomDrop, unsourced }
+}

--- a/src/renderer/src/features/posky/useProgress.ts
+++ b/src/renderer/src/features/posky/useProgress.ts
@@ -28,6 +28,7 @@ import { ambiguousQuestNames, computeSharedItems, type SharedItemsMap } from './
 import { skyDroppersFor, type DropperMob } from './poskyDroppers'
 import { countTurnIns, newlyCompletedTurnIns } from './turnInCelebration'
 import { questDropRecency } from './questSort'
+import { rewardInferredQuests, withRewardInference } from './rewardInference'
 // The turn-in ledger (JOS-131) — the ONE place a turn-in count is decided, shared with main's
 // store so the renderer and the persisted file cannot disagree about what a count means.
 // Relative value import, per the repo's node-tested-module rule.
@@ -159,6 +160,14 @@ export interface QuestProgress {
   /** turned in at least once. Kept as the one-bit reading of `turnIns` for the surfaces that
    *  only need the badge (the Ignored list) and for sorts that predate the count. */
   completed: boolean
+  /**
+   * The count above was INFERRED from the reward item in the loaded inventory export (issue #27),
+   * not read from the log or stated by hand. Present only when that inference is the count's ONLY
+   * source — any ledger evidence wins and leaves this absent — so the UI can say where the
+   * reading came from and the undo control can say why there is nothing to take back
+   * (the classUnlocks.ts observed-vs-derived precedent). Derived on every read, never persisted.
+   */
+  rewardInferred?: true
   /**
    * epoch ms of the NEWEST drop among this quest's required items — the "most recent drop"
    * sort key. Absent when nothing it needs has ever dropped; recency is then unknown, not old.
@@ -595,12 +604,21 @@ export function useProgress(opts?: UseProgressOptions): UseProgress {
   })
 
   const overridesByKey = useMemo(() => itemOverridesByKey(itemOverrides), [itemOverrides])
+  // Which quests the loaded export vouches for (issue #27) — read from the RAW dump counts, not
+  // the reconciled `net`, because the inference is about what the export SAW, whatever count
+  // source the user picked for the farming numbers. Derived on every read, never persisted.
+  const rewardVouched = useMemo(
+    () => rewardInferredQuests(posky.quests, progress?.inventory),
+    [progress?.inventory]
+  )
   const quests = useMemo<QuestProgress[]>(() => {
     if (!progress) return []
     const counts = { all: turnIns.all, log: logCounts }
     const facts = { lastLootedAt, overrides: overridesByKey }
-    return posky.quests.map((q) => computeQuestProgress(q, net, counts, facts))
-  }, [progress, net, lastLootedAt, turnIns, logCounts, overridesByKey])
+    return posky.quests.map((q) =>
+      withRewardInference(computeQuestProgress(q, net, counts, facts), rewardVouched)
+    )
+  }, [progress, net, lastLootedAt, turnIns, logCounts, overridesByKey, rewardVouched])
 
   const classes = useMemo(() => [...new Set(posky.quests.map((q) => q.className))].sort(), [])
 

--- a/src/renderer/src/features/posky/useQuestList.ts
+++ b/src/renderer/src/features/posky/useQuestList.ts
@@ -28,17 +28,21 @@ import { filterByQuery } from './questSearch'
 // has-every-item-now, JOS-145 for has-ever-turned-in). Two lines of code, a page of reasoning, and
 // a node test — so they live in their own pure module.
 import { everTurnedIn, firstTimeReady, hasEveryItem, readyQuests } from './questCompletion'
+// The Targets tab's whole model (issue #30) — pure, node-tested, and fed the VISIBLE set below so
+// ignoring a quest takes its wants out of the kill list by the same one rule every tab obeys.
+import { skyTargets, type SkyTargetsModel } from './skyTargets'
 
 export type { SortKey }
 
 /**
- * Quests · Ready · Cleanup · Classes · Ignored. `ready` is JOS-147's turn-in list (rule in
- * questCompletion); `cleanup` is JOS-389's spare-items list (rule in cleanup.ts); `classes` is
- * JOS-148's per-class unlock progress (rule in classUnlocks.ts). None of them reads any of the
- * filter state below — they are derivations over the same quests, which is why the tab key is the
- * only thing each of them adds to this hook.
+ * Quests · Ready · Targets · Cleanup · Classes · Ignored. `ready` is JOS-147's turn-in list (rule
+ * in questCompletion); `targets` is issue #30's kill list (rule in skyTargets.ts); `cleanup` is
+ * JOS-389's spare-items list (rule in cleanup.ts); `classes` is JOS-148's per-class unlock
+ * progress (rule in classUnlocks.ts). None of them reads any of the filter state below — they are
+ * derivations over the same quests, which is why the tab key is the only thing each of them adds
+ * to this hook.
  */
-export type TabKey = 'quests' | 'ready' | 'cleanup' | 'classes' | 'ignored'
+export type TabKey = 'quests' | 'ready' | 'targets' | 'cleanup' | 'classes' | 'ignored'
 
 // How many Accordions to render before the "show more" cap kicks in. Exported because the LIST'S
 // FOOTER has to know it too (PoskyView.ListFooter): once "show all" is on there is no cap left to
@@ -258,6 +262,17 @@ function useReadySet(allReady: QuestProgress[]): {
 }
 
 
+/**
+ * The Targets tab's model (issue #30), derived from the VISIBLE quests and from nothing else —
+ * not the class filter, not the facets, not the hide-boxes, on the Ready tab's exact argument:
+ * the controls are not drawn on this tab, so no invisible state can be narrowing it. Its own
+ * hook, like `useReadySet` above, so `useQuestList`'s body stays under the measured per-function
+ * ceiling. The tab's COUNT reads `targets.mobs.length` — the same array the pane draws.
+ */
+function useTargetsModel(visible: QuestProgress[]): SkyTargetsModel {
+  return useMemo(() => skyTargets(visible), [visible])
+}
+
 interface QuestSelection {
   quests: QuestProgress[]
   selectedClasses: string[]
@@ -331,6 +346,13 @@ export interface QuestListState {
    * of the tab's count, because the count IS this array's length.
    */
   ready: QuestProgress[]
+  /**
+   * The Targets tab (issue #30): every mob still worth killing for the quests you have never
+   * turned in, plus the two honest remainders (the random-drop Wind Runes and the items nothing
+   * committed can source). Derived from `visible` only — the rule and its arguments live in
+   * skyTargets.ts.
+   */
+  targets: SkyTargetsModel
   /** `visible` after the filters, the sort and the favorite pinning */
   filtered: QuestProgress[]
   selectedClasses: string[]
@@ -485,6 +507,9 @@ export function useQuestList(quests: QuestProgress[]): QuestListState {
   // holding back. The tab's COUNT reads the same array the pane draws, so the number on the tab
   // and the rows under it can never disagree.
   const readySet = useReadySet(allReady)
+  // The Targets tab, whole (issue #30). Same shape as the Ready line above: the derivation is a
+  // pure module, the hook is one memo, and the tab count reads the array the pane draws.
+  const targets = useTargetsModel(visible)
 
   // What the two facet pickers can offer. Derived from the VISIBLE quests, so an ignored quest
   // takes its island and its boss out of the pickers along with itself.
@@ -544,6 +569,7 @@ export function useQuestList(quests: QuestProgress[]): QuestListState {
     ignored,
     // `ready`, the toggle and its setter, and the held-back count, all from the one hook above.
     ...readySet,
+    targets,
     filtered,
     selectedClasses,
     setSelectedClasses,

--- a/src/shared/questTurnIns.ts
+++ b/src/shared/questTurnIns.ts
@@ -30,6 +30,15 @@
 // completion is real but UNDATED, so it contributes a FLOOR OF ONE to the count and nothing else.
 // `completedQuests` keeps being written as the downgrade mirror (see shared/types.ts).
 //
+// AND ONE FLOOR THIS LEDGER DOES NOT SEE (issue #27): the Sky tab's DISPLAYED count is decided in
+// two stages. This module resolves the persisted + detected evidence; the renderer then floors a
+// quest at one when its untradeable reward sits in the loaded inventory export
+// (renderer/features/posky/rewardInference.ts), derived on every read and never written back
+// here. Two stated consequences: any OTHER consumer of this ledger reads the un-floored count and
+// may say "not turned in" where the Sky tab says "Turned in"; and the downgrade mirror never
+// contains an inferred completion, so an older build shows those quests un-done — both are the
+// price of keeping derived evidence out of the persisted record, paid on purpose.
+//
 // THERE IS NO "SINCE THE DUMP" COUNT ANY MORE (JOS-141). This file used to report a second count
 // — how many turn-ins landed after the loaded dump was generated — because JOS-128 made a dump
 // load RESET the held-count model, and a base of `dump + loot since the dump` already had every

--- a/tests/e2e/sky-targets.e2e.mts
+++ b/tests/e2e/sky-targets.e2e.mts
@@ -88,11 +88,7 @@ async function stepPane(page: Page): Promise<void> {
   const rows = await settle(() => countOf(page, ROW), (n) => n > 0, { timeoutMs: 30_000 })
   check('the fixture leaves mobs still worth killing', rows > 0, `rows=${String(rows)}`)
   const count = await page.evaluate((sel) => document.querySelector(sel)?.textContent ?? '', COUNT)
-  check(
-    'the pane states its order and that it is derived, never a guess',
-    count.includes('sort first') && count.includes('Derived from your quest progress'),
-    count.slice(0, 200)
-  )
+  check('the pane states its ordering rule - state, never process', count.includes('sort first'), count.slice(0, 200))
   const label = await labelCount(page)
   check(
     'THE TAB LABEL COUNTS THE MOB CARDS - the same array the pane draws',
@@ -152,9 +148,25 @@ async function stepLiveArc(page: Page, log: FixtureLog, at: Date): Promise<void>
   check('LOOTING THE LAST ITEMS TAKES THE QUEST OFF THE LIST - nothing left to grind', !looted.includes(MARKER))
 
   log.appendAt(new Date(at.getTime() + 30_000), ...TURN_IN)
-  // The turn-in spends the items AND counts the quest as run: under the first-time need set the
-  // wants must NOT come back, even though the spent items would otherwise read as needed again.
-  const settled = await settle(() => paneText(page), (t) => !t.includes(MARKER), { timeoutMs: 30_000 })
+  // The turn-in spends the items AND counts the quest as run. "Keeps it off" can only be
+  // asserted AFTER the trade has demonstrably landed - the marker is already absent from the
+  // loot step, so a poll that raced the tailer would pass vacuously. The evidence is the quest's
+  // own turned-in badge on the Quests tab; only then is the Targets pane's silence meaningful.
+  await page.click(TAB_QUESTS, { timeout: 15_000 })
+  await page.waitForSelector(COUNTS, { timeout: 15_000 })
+  await page.fill(SEARCH, 'Test of Azarack', { timeout: 15_000 })
+  const badge = await settle(
+    () => countOf(page, '[data-testid="posky-turned-in"]'),
+    (c) => c > 0,
+    { timeoutMs: 30_000 }
+  )
+  if (!check('the trade landed: the quest wears its turned-in badge', badge > 0)) return
+  await page.fill(SEARCH, '', { timeout: 15_000 })
+  await page.click(TAB_TARGETS, { timeout: 15_000 })
+  await page.waitForSelector(PANE, { timeout: 15_000 })
+  // The spent items would read as needed again under hasEveryItem - the first-time need set is
+  // what keeps a run quest out, and this is the assertion that proves it, post-evidence.
+  const settled = await paneText(page)
   check('…AND THE TURN-IN KEEPS IT OFF: a run quest never rejoins the first-time need set', !settled.includes(MARKER))
 }
 

--- a/tests/e2e/sky-targets.e2e.mts
+++ b/tests/e2e/sky-targets.e2e.mts
@@ -1,0 +1,192 @@
+/**
+ * Headless Electron integration test for THE TARGETS TAB (issue #30) — the Sky tracker's kill
+ * list: every mob still worth killing for the quests you have never turned in, plus the two
+ * honest remainders (the random-drop Wind Runes and the items nothing committed can source).
+ *
+ * WHY THIS NEEDS A REAL APP. The fold itself is unit-tested against the real pure code
+ * (tests/skyTargets.test.mts). What no unit test can see is the CHAIN the tab's whole promise
+ * rests on: that the list moves LIVE — an ignore flag flipped on the Quests tab, a loot line
+ * travelling chokidar to Tailer to the loot ledger, a trade closing a quest — each re-derives
+ * the pane with no reload anywhere. JOS-87 is the standing reminder that chains break at seams
+ * every unit test is happy with.
+ *
+ * EVERY LINE SHAPE IS COPIED FROM THE OWNER'S REAL LOG, never invented (the awaiting-sample law)
+ * — the same proven Beastlord Test of Azarack lines sky-turnin.e2e.mts and
+ * sky-class-unlocks.e2e.mts drive. That quest is also the right subject HERE for a reason those
+ * specs did not need: its two items are exactly the tab's two remainder paths — Azarack Skin is
+ * one of the three items no catalog page sources (the no-known-source note), and Wind Rune Heda
+ * is a random drop (the collective entry). So the arc below exercises the honest-rendering
+ * sections, not only the mob cards.
+ *
+ * NUMBERS ARE RELATIVE, NEVER FROZEN: the committed Sky data can gain quests and mobs, so every
+ * assertion is a floor, a delta, or a property (presence, agreement between the tab label and the
+ * rows) that holds at any count.
+ *
+ * Run: `npm run test:e2e -- sky-targets`.
+ */
+import type { Page } from 'playwright-core'
+import { buildIfStale, check, countOf, dumpArtifacts, failures, reportRun, settle } from './appHarness.mjs'
+import { mainWindow } from './appWindow.mjs'
+import { launchOnFixture, stageFixture, type FixtureLog } from './logFixture.mjs'
+
+const NAV_SKY = '[data-testid="nav-posky"]'
+const NAV_OVERVIEW = '[data-testid="nav-overview"]'
+const TAB_TARGETS = '[data-testid="posky-tab-targets"]'
+const TAB_QUESTS = '[data-testid="posky-tab-quests"]'
+const TAB_IGNORED = '[data-testid="posky-tab-ignored"]'
+const PANE = '[data-testid="posky-targets"]'
+const COUNT = '[data-testid="posky-targets-count"]'
+const ROW = '[data-testid^="sky-target-row-"]'
+const SEARCH = '[data-testid="posky-search"] input'
+const COUNTS = '[data-testid="posky-counts"]'
+/** The flag buttons carry no testid; their aria-labels are the stable words the user hears. */
+const IGNORE = '[aria-label="Ignore this quest permanently"]'
+const UNIGNORE = '[aria-label="Stop ignoring this quest"]'
+
+/** The quest driven live, and the verbatim lines that do it (shapes from the real log). */
+const GIVER = 'Animist Kratho'
+const ITEMS = ['Azarack Skin', 'Wind Rune Heda'] as const
+const LOOT = [
+  `--You have looted an ${ITEMS[0]} from Protector of Sky's corpse.--`,
+  `--You have looted a ${ITEMS[1]} from an azarack's corpse.--`
+]
+const TURN_IN = [
+  ...ITEMS.map((i) => `You offered 1 ${i} to ${GIVER}.`),
+  `You complete the trade with ${GIVER}.`
+]
+/** The item whose presence tracks the Beastlord quest's contribution: it is needed by that quest
+ *  alone, so it appears and disappears with it (Wind Rune Heda is shared and would not). */
+const MARKER = ITEMS[0]
+
+/** The pane's whole text — presence is asserted on words, the way a player reads the tab. */
+function paneText(page: Page): Promise<string> {
+  return page.evaluate((sel) => document.querySelector(sel)?.textContent ?? '', PANE)
+}
+
+/** The tab label's own count, or null while the tab is countless. */
+function labelCount(page: Page): Promise<number | null> {
+  return page.evaluate((sel) => {
+    const m = /Targets \((\d+)\)/.exec(document.querySelector(sel)?.textContent ?? '')
+    return m ? Number(m[1]) : null
+  }, TAB_TARGETS)
+}
+
+/** Open the Sky tab, then the Targets tab, and wait for the pane. */
+async function openTargets(page: Page): Promise<boolean> {
+  await page.click(NAV_SKY, { timeout: 30_000 })
+  await page.waitForSelector(TAB_TARGETS, { timeout: 60_000 })
+  await page.click(TAB_TARGETS, { timeout: 15_000 })
+  const shown = await page.waitForSelector(PANE, { timeout: 30_000 }).then(
+    () => true,
+    () => false
+  )
+  return check('the Targets tab opens onto its own pane', shown)
+}
+
+/** Rows, the derived statement, and the one agreement that matters: label count = row count. */
+async function stepPane(page: Page): Promise<void> {
+  const rows = await settle(() => countOf(page, ROW), (n) => n > 0, { timeoutMs: 30_000 })
+  check('the fixture leaves mobs still worth killing', rows > 0, `rows=${String(rows)}`)
+  const count = await page.evaluate((sel) => document.querySelector(sel)?.textContent ?? '', COUNT)
+  check(
+    'the pane states its order and that it is derived, never a guess',
+    count.includes('sort first') && count.includes('Derived from your quest progress'),
+    count.slice(0, 200)
+  )
+  const label = await labelCount(page)
+  check(
+    'THE TAB LABEL COUNTS THE MOB CARDS - the same array the pane draws',
+    label === rows,
+    `label=${String(label)} rows=${String(rows)}`
+  )
+  const covered = await page.evaluate(
+    (sel) => [...document.querySelectorAll(sel)].every((el) => Number(el.getAttribute('data-covers')) >= 1),
+    ROW
+  )
+  check('every row says how many needed items its mob covers', covered)
+}
+
+/**
+ * AE3, LIVE: ignoring a quest takes its wants out of the kill list; un-ignoring restores them.
+ * The flag is flipped on the QUESTS tab — a different tab entirely — which is exactly the chain
+ * the unit tests cannot see: one localStorage flag, read through useVisibleQuests, re-deriving
+ * this pane with nothing reloaded.
+ */
+async function stepIgnoreRemoves(page: Page): Promise<void> {
+  const before = await settle(() => paneText(page), (t) => t.includes(MARKER), { timeoutMs: 20_000 })
+  if (!check('the marker item is on the pane before anything is flagged', before.includes(MARKER))) return
+
+  await page.click(TAB_QUESTS, { timeout: 15_000 })
+  await page.waitForSelector(COUNTS, { timeout: 15_000 })
+  await page.fill(SEARCH, 'Test of Azarack', { timeout: 15_000 })
+  await page.waitForSelector(IGNORE, { timeout: 15_000 })
+  await page.click(IGNORE, { timeout: 15_000 })
+  await page.fill(SEARCH, '', { timeout: 15_000 })
+
+  await page.click(TAB_TARGETS, { timeout: 15_000 })
+  await page.waitForSelector(PANE, { timeout: 15_000 })
+  const gone = await settle(() => paneText(page), (t) => !t.includes(MARKER), { timeoutMs: 20_000 })
+  check('IGNORING THE QUEST TAKES ITS ITEM OFF THE KILL LIST, LIVE', !gone.includes(MARKER))
+
+  await page.click(TAB_IGNORED, { timeout: 15_000 })
+  await page.waitForSelector(UNIGNORE, { timeout: 15_000 })
+  await page.click(UNIGNORE, { timeout: 15_000 })
+  await page.click(TAB_TARGETS, { timeout: 15_000 })
+  await page.waitForSelector(PANE, { timeout: 15_000 })
+  const back = await settle(() => paneText(page), (t) => t.includes(MARKER), { timeoutMs: 20_000 })
+  check('…and un-ignoring on the Ignored tab puts it straight back', back.includes(MARKER))
+}
+
+/**
+ * AE7, LIVE, in two honest halves. Looting the items zeroes the shortfall — the quest has
+ * nothing left to grind, so its wants leave the list BEFORE any turn-in. Handing them over then
+ * turns the quest in, which is the state the first-time need set never readmits. Both
+ * transitions arrive through the tailed log with no reload.
+ */
+async function stepLiveArc(page: Page, log: FixtureLog, at: Date): Promise<void> {
+  const before = await paneText(page)
+  if (!check('the marker item is back on the pane before the live arc', before.includes(MARKER))) return
+
+  log.appendAt(at, ...LOOT)
+  const looted = await settle(() => paneText(page), (t) => !t.includes(MARKER), { timeoutMs: 30_000 })
+  check('LOOTING THE LAST ITEMS TAKES THE QUEST OFF THE LIST - nothing left to grind', !looted.includes(MARKER))
+
+  log.appendAt(new Date(at.getTime() + 30_000), ...TURN_IN)
+  // The turn-in spends the items AND counts the quest as run: under the first-time need set the
+  // wants must NOT come back, even though the spent items would otherwise read as needed again.
+  const settled = await settle(() => paneText(page), (t) => !t.includes(MARKER), { timeoutMs: 30_000 })
+  check('…AND THE TURN-IN KEEPS IT OFF: a run quest never rejoins the first-time need set', !settled.includes(MARKER))
+}
+
+async function main(): Promise<void> {
+  buildIfStale()
+
+  const log = stageFixture('e2e-copy.log')
+  const now = Date.now()
+  try {
+    const launched = await launchOnFixture(log)
+    let page: Page | null = null
+    try {
+      page = await mainWindow(launched.app)
+      await page.waitForSelector(NAV_OVERVIEW, { timeout: 60_000 })
+      if (!(await openTargets(page))) {
+        throw new Error('never reached the Targets tab - nothing below can be asserted')
+      }
+      await stepPane(page)
+      await stepIgnoreRemoves(page)
+      await stepLiveArc(page, log, new Date(now - 60_000))
+      if (failures.length) await dumpArtifacts(page, 'sky-targets-FAIL')
+    } finally {
+      await launched.close()
+    }
+  } finally {
+    await log.dispose()
+  }
+
+  reportRun()
+}
+
+main().catch((err: unknown) => {
+  console.error('e2e: harness error -', err)
+  process.exitCode = 1
+})

--- a/tests/rewardInference.test.mts
+++ b/tests/rewardInference.test.mts
@@ -1,0 +1,172 @@
+// ============================================================================
+// Issue #27 — a quest whose REWARD is in the inventory export has been turned in.
+// ============================================================================
+//
+// THE REPORT (github issue #27, and reproduced on a second install): a fresh install loads an
+// inventory export, the export plainly contains a Sky quest's reward item, and the quest still
+// reads "not turned in". Nothing was broken — nothing ever consulted the reward. The ledger
+// (shared/questTurnIns.ts) has exactly three sources: log-detected trades, hand statements, and
+// the legacy `completedQuests` key. A turn-in done before logging was on leaves none of those.
+//
+// WHY THE INFERENCE IS SOUND, measured against the committed data (2026-08-16): every one of the
+// 95 Sky quests has a reward, every reward is UNIQUE to its quest, none appears as a drop
+// anywhere in the items DB, none is consumed by another Sky quest, and 92 of 94 in the DB are
+// NO DROP. Holding the reward proves at least one turn-in the same way a log line would.
+//
+// WHAT THIS SUITE PINS:
+//   1. THE SET (`rewardInferredQuests`): which quest keys the loaded export vouches for —
+//      matching on the same counting key the held counts use (lowercased, `+N` folded), so an
+//      exalted reward still testifies for its quest. A quest with no reward in the data never
+//      infers; an absent export infers nothing.
+//   2. THE FLOOR (`withRewardInference`): a vouched-for quest with NO other evidence reads
+//      turnIns 1 / completed, and says WHERE the reading came from (`rewardInferred`), because a
+//      reader who cannot tell "the log said so" from "we worked it out" cannot tell which rows
+//      to trust (the classUnlocks.ts precedent). Real evidence wins: any ledger count leaves the
+//      quest untouched and unlabelled.
+//   3. WHAT IT NEVER TOUCHES: the inference is DERIVED state — applied after
+//      `computeQuestProgress`, never written to the ledger — so consumption, the celebration
+//      baseline and persistence never see it. An inferred turn-in predates the log, so its items
+//      were never in the log counts and it owes no subtraction (the "a dump owes none" rule,
+//      one storey up).
+//   4. THE COMPOSITIONS: `everTurnedIn` reads an inferred quest as run, so the hide-turned-in
+//      box, the class-unlock derivation and the Ready tab's first-time default all get the same
+//      answer without reading a second field.
+//
+// ONE-DIRECTIONAL, deliberately: reward present ⇒ turned in; reward ABSENT proves nothing (the
+// export only covers what was open when it was written — a banked reward is invisible). Nothing
+// here ever un-completes a quest, which is the same promise "a dump adds, it never subtracts"
+// already makes about counts.
+//
+// Run: `npm test`.
+
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  rewardInferredQuests,
+  withRewardInference
+} from '../src/renderer/src/features/posky/rewardInference'
+import { everTurnedIn, firstTimeReady } from '../src/renderer/src/features/posky/questCompletion'
+import type { QuestProgress } from '../src/renderer/src/features/posky/useProgress'
+
+// =============================================================================
+// 1. The set: which quests the export vouches for
+// =============================================================================
+
+/** The three fields the inference reads; everything else on PoskyQuest is not its business. */
+const QUESTS = [
+  { className: 'Cleric', name: 'Cleric Test of Resolution', reward: 'Necklace of Resolution' },
+  { className: 'Wizard', name: 'Wizard Test of Focus', reward: "Al`Kabor's Cap of Binding" },
+  { className: 'Rogue', name: 'Rogue Test of Thievery', reward: 'Wispy Choker of Vigor' },
+  // The data has no quest without a reward today; the type allows one, so the rule must too.
+  { className: 'Monk', name: 'Monk Test of Stone', reward: undefined }
+]
+
+test('a reward sitting in the export vouches for its quest', () => {
+  const keys = rewardInferredQuests(QUESTS, { 'necklace of resolution': 1 })
+  assert.ok(keys.has('Cleric::Cleric Test of Resolution'))
+  assert.equal(keys.size, 1)
+})
+
+test('an exalted reward still testifies: the +N variant folds onto the counting key', () => {
+  // heldCountsFromDump keys are the RAW name lowercased — the fold is the inference's job.
+  const keys = rewardInferredQuests(QUESTS, { "al`kabor's cap of binding +2": 1 })
+  assert.ok(keys.has('Wizard::Wizard Test of Focus'))
+})
+
+test('a quest with no reward in the data never infers (missing data, not a finished quest)', () => {
+  const keys = rewardInferredQuests(QUESTS, { 'necklace of resolution': 1, undefined: 1 })
+  assert.ok(!keys.has('Monk::Monk Test of Stone'))
+})
+
+test('an absent reward proves nothing, and an absent export proves nothing about anything', () => {
+  assert.equal(rewardInferredQuests(QUESTS, { 'wispy choker of vigor': 1 }).size, 1)
+  assert.equal(rewardInferredQuests(QUESTS, {}).size, 0)
+  assert.equal(rewardInferredQuests(QUESTS, undefined).size, 0)
+})
+
+test('a zero or negative count is an absent item, not a held one', () => {
+  const keys = rewardInferredQuests(QUESTS, {
+    'necklace of resolution': 0,
+    'wispy choker of vigor': -1
+  })
+  assert.equal(keys.size, 0)
+})
+
+// =============================================================================
+// 2. The floor, and what real evidence does to it
+// =============================================================================
+
+/** A QuestProgress as a quest nobody has touched would carry it (the questRow precedent). */
+function questRow(p: { className: string; name: string; turnIns?: number }): QuestProgress {
+  const turnIns = p.turnIns ?? 0
+  return {
+    key: `${p.className}::${p.name}`,
+    className: p.className,
+    name: p.name,
+    items: [],
+    haveCount: 0,
+    needCount: 2,
+    ratio: 0,
+    missing: ['Wind Rune Ena', 'Pulsating Ruby'],
+    turnIns,
+    logTurnIns: 0,
+    completed: turnIns >= 1
+  }
+}
+
+const VOUCHED = new Set(['Cleric::Cleric Test of Resolution'])
+
+test('no other evidence + reward held → turnIns floors at 1, completed, and says why', () => {
+  const q = withRewardInference(questRow({ className: 'Cleric', name: 'Cleric Test of Resolution' }), VOUCHED)
+  assert.equal(q.turnIns, 1)
+  assert.equal(q.completed, true)
+  assert.equal(q.rewardInferred, true)
+  // The log's share is untouched: nothing here is log evidence.
+  assert.equal(q.logTurnIns, 0)
+})
+
+test('a quest the export does not vouch for is returned untouched and unlabelled', () => {
+  const before = questRow({ className: 'Rogue', name: 'Rogue Test of Thievery' })
+  const after = withRewardInference(before, VOUCHED)
+  assert.equal(after.turnIns, 0)
+  assert.equal(after.completed, false)
+  assert.equal(after.rewardInferred, undefined)
+})
+
+test('real evidence wins: a ledger count is never floored, relabelled or double-counted', () => {
+  const q = withRewardInference(
+    questRow({ className: 'Cleric', name: 'Cleric Test of Resolution', turnIns: 2 }),
+    VOUCHED
+  )
+  assert.equal(q.turnIns, 2)
+  assert.equal(q.rewardInferred, undefined)
+})
+
+test('the transform is pure: the input row is not mutated', () => {
+  const before = questRow({ className: 'Cleric', name: 'Cleric Test of Resolution' })
+  withRewardInference(before, VOUCHED)
+  assert.equal(before.turnIns, 0)
+  assert.equal(before.completed, false)
+  assert.equal((before as { rewardInferred?: true }).rewardInferred, undefined)
+})
+
+// =============================================================================
+// 3. The compositions: one field, every downstream reading agrees
+// =============================================================================
+
+test('everTurnedIn reads an inferred quest as run — hide-turned-in and class unlocks follow', () => {
+  const q = withRewardInference(questRow({ className: 'Cleric', name: 'Cleric Test of Resolution' }), VOUCHED)
+  assert.equal(everTurnedIn(q), true)
+})
+
+test('the Ready tab’s first-time default drops an inferred quest: it has been run', () => {
+  const inferred = withRewardInference(
+    questRow({ className: 'Cleric', name: 'Cleric Test of Resolution' }),
+    VOUCHED
+  )
+  const fresh = questRow({ className: 'Rogue', name: 'Rogue Test of Thievery' })
+  assert.deepEqual(
+    firstTimeReady([inferred, fresh]).map((q) => q.key),
+    ['Rogue::Rogue Test of Thievery']
+  )
+})

--- a/tests/rewardInference.test.mts
+++ b/tests/rewardInference.test.mts
@@ -52,13 +52,37 @@ import type { QuestProgress } from '../src/renderer/src/features/posky/useProgre
 // 1. The set: which quests the export vouches for
 // =============================================================================
 
-/** The three fields the inference reads; everything else on PoskyQuest is not its business. */
+/** The four fields the inference reads; everything else on PoskyQuest is not its business. */
 const QUESTS = [
-  { className: 'Cleric', name: 'Cleric Test of Resolution', reward: 'Necklace of Resolution' },
-  { className: 'Wizard', name: 'Wizard Test of Focus', reward: "Al`Kabor's Cap of Binding" },
-  { className: 'Rogue', name: 'Rogue Test of Thievery', reward: 'Wispy Choker of Vigor' },
+  {
+    className: 'Cleric',
+    name: 'Cleric Test of Resolution',
+    reward: 'Necklace of Resolution',
+    rewardStats: 'MAGIC ITEM LORE ITEM NO DROP\nSlot: NECK'
+  },
+  {
+    className: 'Wizard',
+    name: 'Wizard Test of Focus',
+    reward: "Al`Kabor's Cap of Binding",
+    rewardStats: 'MAGIC ITEM LORE ITEM NO DROP\nSlot: HEAD'
+  },
+  {
+    className: 'Rogue',
+    name: 'Rogue Test of Thievery',
+    reward: 'Wispy Choker of Vigor',
+    // The newer scrape shape spells it "No Trade" - both spellings are the same fact.
+    rewardStats: 'Lore Equipped, No Trade\nSlot: NECK'
+  },
+  // The two REAL tradeable rewards (the committed DB's only ones): no NO DROP, no No Trade.
+  // Holding one proves nothing - it can be bought or handed over - so it never vouches.
+  {
+    className: 'Necromancer',
+    name: 'Necromancer Test of Heart',
+    reward: 'Sphinx Heart Amulet',
+    rewardStats: 'MAGIC ITEM LORE ITEM\nSlot: NECK'
+  },
   // The data has no quest without a reward today; the type allows one, so the rule must too.
-  { className: 'Monk', name: 'Monk Test of Stone', reward: undefined }
+  { className: 'Monk', name: 'Monk Test of Stone', reward: undefined, rewardStats: undefined }
 ]
 
 test('a reward sitting in the export vouches for its quest', () => {
@@ -90,6 +114,23 @@ test('a zero or negative count is an absent item, not a held one', () => {
     'wispy choker of vigor': -1
   })
   assert.equal(keys.size, 0)
+})
+
+test('a TRADEABLE reward proves nothing: possession is only evidence when the item cannot move', () => {
+  // Sphinx Heart Amulet carries no NO DROP / No Trade - it can be bought or handed over, so
+  // holding it does not prove the quest was run. The other 92 rewards all state one of the two.
+  const keys = rewardInferredQuests(QUESTS, { 'sphinx heart amulet': 1 })
+  assert.equal(keys.size, 0)
+})
+
+test('both untradeable spellings vouch: the old scrape says NO DROP, the newer says No Trade', () => {
+  const keys = rewardInferredQuests(QUESTS, {
+    'necklace of resolution': 1,
+    'wispy choker of vigor': 1
+  })
+  assert.ok(keys.has('Cleric::Cleric Test of Resolution'))
+  assert.ok(keys.has('Rogue::Rogue Test of Thievery'))
+  assert.equal(keys.size, 2)
 })
 
 // =============================================================================

--- a/tests/skyTargets.test.mts
+++ b/tests/skyTargets.test.mts
@@ -1,0 +1,272 @@
+// ============================================================================
+// skyTargets — the Targets tab's whole model: "who do I still kill", cross-quest.
+// ============================================================================
+//
+// Issue #30, planned in docs/plans/sky-targets.md from
+// docs/brainstorms/2026-08-16-sky-targets-tab-requirements.md. The quest tracker says what each
+// quest needs; players invert it in their heads to the question they walk the islands with. This
+// suite pins the inversion as a pure fold, half against the COMMITTED data (the poskyDroppers
+// precedent: goldens over posky.json + the real catalog) and half against synthetic quests where
+// the committed data cannot express the case (partial holdings, turn-in counts).
+//
+// WHAT IS PINNED, and the argument for each:
+//   1. THE NEED SET is never-turned-in and nothing else (`everTurnedIn`, the Ready tab's
+//      first-time reading). A reward-inferred completion (PR #33) reads turnIns >= 1 and is
+//      excluded by the same predicate — no special case, which is the point of the floor.
+//   2. SHORTFALL AGGREGATES PER COUNTING KEY, never per quest. `computeQuestProgress` clamps
+//      `have` per quest with no cross-quest allocation, so a per-quest `have < need` filter
+//      would read two quests each "satisfied" by the same single held copy. The rule:
+//      totalNeed summed over the need set, minus the UNCAPPED `held`, floored at zero.
+//   3. CLASSIFICATION IS THE SCRAPE'S OWN WORDS: resolved droppers fold into mob cards; an
+//      unresolved item whose `who` starts with "random drop" (case-insensitive prefix — never
+//      the literal sentinel, which carries an em dash `tests/copyNoEmDash.test.mts` would
+//      reject) is the collective entry; anything else unresolved is the no-known-source list.
+//      Never a guessed mob (law 1).
+//   4. THE ORDER IS COUNTED: mobs by distinct needed items covered, desc, then name — the
+//      questKillTargets order, cross-quest. Items inside a card, and both special lists,
+//      alphabetical: deterministic and explainable, nothing invented.
+//
+// Run: `npm test`.
+
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { skyTargets, type TargetsQuest, type TargetsQuestItem } from '../src/renderer/src/features/posky/skyTargets'
+import { skyDroppersFor, type DropperMob } from '../src/renderer/src/features/posky/poskyDroppers'
+import type { MobEntry, PoskyQuest } from '../src/shared/types'
+import poskyRaw from '../src/renderer/src/data/eqlegends/posky.json' with { type: 'json' }
+
+const QUESTS: PoskyQuest[] = (poskyRaw as { quests: PoskyQuest[] }).quests
+
+// ---------------------------------------------------------------------------
+// Builders
+// ---------------------------------------------------------------------------
+
+/** A synthetic dropper — the catalog shape with only the fields the fold reads. */
+function mob(name: string, page = name): DropperMob {
+  const entry = { name, page, zones: ['Plane of Sky'] } as MobEntry
+  return { name, page, zones: ['Plane of Sky'], entry }
+}
+
+/** One quest item as the fold consumes it; droppers default to none. */
+function item(p: {
+  name: string
+  need?: number
+  held?: number
+  droppers?: DropperMob[]
+  where?: string
+  who?: string[]
+}): TargetsQuestItem {
+  return {
+    name: p.name,
+    need: p.need ?? 1,
+    held: p.held ?? 0,
+    droppers: p.droppers ?? [],
+    where: p.where ?? 'Island 1',
+    who: p.who ?? []
+  }
+}
+
+/** A quest as the fold consumes it. `turnIns` defaults to never-turned-in. */
+function quest(p: {
+  className?: string
+  name: string
+  turnIns?: number
+  items: TargetsQuestItem[]
+}): TargetsQuest {
+  return {
+    className: p.className ?? 'Warrior',
+    name: p.name,
+    turnIns: p.turnIns ?? 0,
+    items: p.items
+  }
+}
+
+/** A REAL quest row from the committed data, resolved through the real dropper index. */
+function realQuest(q: PoskyQuest, turnIns = 0): TargetsQuest {
+  return {
+    className: q.className,
+    name: q.name,
+    turnIns,
+    items: q.items.map((it) => ({
+      name: it.name,
+      need: it.count > 0 ? it.count : 1,
+      held: 0,
+      droppers: skyDroppersFor(it.name, it.who),
+      where: it.where,
+      who: it.who
+    }))
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 1. The need set
+// ---------------------------------------------------------------------------
+
+test('a quest turned in once contributes nothing (AE1)', () => {
+  const q = quest({ name: 'Test of Done', turnIns: 1, items: [item({ name: 'Sky Pearl', droppers: [mob('Gorgalosk')] })] })
+  const model = skyTargets([q])
+  assert.equal(model.mobs.length, 0)
+  assert.equal(model.randomDrop.length, 0)
+  assert.equal(model.unsourced.length, 0)
+})
+
+test('a reward-inferred completion is excluded by the same predicate (AE2)', () => {
+  // PR #33 floors turnIns to 1 when the reward sits in the inventory export; the fold reads
+  // the floored count and needs no rewardInferred special case.
+  const q = quest({ name: 'Test of Inferred', turnIns: 1, items: [item({ name: 'Sky Pearl', droppers: [mob('Gorgalosk')] })] })
+  assert.equal(skyTargets([q]).mobs.length, 0)
+})
+
+test('a quest holding everything contributes nothing; an empty input is an empty model', () => {
+  const full = quest({ name: 'Test of Full', items: [item({ name: 'Sky Pearl', need: 2, held: 2, droppers: [mob('Gorgalosk')] })] })
+  assert.equal(skyTargets([full]).mobs.length, 0)
+  const empty = skyTargets([])
+  assert.deepEqual([empty.mobs, empty.randomDrop, empty.unsourced], [[], [], []])
+})
+
+// ---------------------------------------------------------------------------
+// 2. Shortfall aggregates per counting key
+// ---------------------------------------------------------------------------
+
+test('two quests sharing one held copy still need one more — never vanishing (the R2 rule)', () => {
+  const a = quest({ className: 'Cleric', name: 'Test A', items: [item({ name: 'Sphinx Claw', held: 1, droppers: [mob('Sphinx')] })] })
+  const b = quest({ className: 'Rogue', name: 'Test B', items: [item({ name: 'Sphinx Claw', held: 1, droppers: [mob('Sphinx')] })] })
+  const model = skyTargets([a, b])
+  assert.equal(model.mobs.length, 1)
+  const entry = model.mobs[0].items[0]
+  // totalNeed 2 across the need set, 1 held -> 1 short. The per-quest clamp would say 0.
+  assert.equal(entry.shortfall, 1)
+  assert.equal(entry.quests.length, 2)
+})
+
+test('one item wanted by two quests is one mob entry naming both, with combined shortfall (AE4)', () => {
+  const a = quest({ className: 'Cleric', name: 'Test A', items: [item({ name: 'Sphinx Claw', droppers: [mob('Sphinx')] })] })
+  const b = quest({ className: 'Rogue', name: 'Test B', items: [item({ name: 'Sphinx Claw', droppers: [mob('Sphinx')] })] })
+  const model = skyTargets([a, b])
+  assert.equal(model.mobs.length, 1)
+  assert.equal(model.mobs[0].mob.name, 'Sphinx')
+  const entry = model.mobs[0].items[0]
+  assert.equal(entry.shortfall, 2)
+  assert.deepEqual(entry.quests.map((x) => x.questName).sort(), ['Test A', 'Test B'])
+})
+
+test('a +N variant folds onto its base item by counting key', () => {
+  const a = quest({ className: 'Cleric', name: 'Test A', items: [item({ name: 'Sphinx Claw', droppers: [mob('Sphinx')] })] })
+  const b = quest({ className: 'Rogue', name: 'Test B', items: [item({ name: 'Sphinx Claw +1', droppers: [mob('Sphinx')] })] })
+  const model = skyTargets([a, b])
+  assert.equal(model.mobs.length, 1)
+  assert.equal(model.mobs[0].items.length, 1)
+  assert.equal(model.mobs[0].items[0].shortfall, 2)
+})
+
+test('need > 1 with partial holdings reports the exact shortfall', () => {
+  const q = quest({ name: 'Test of Two', items: [item({ name: 'Sky Pearl', need: 2, held: 1, droppers: [mob('Gorgalosk')] })] })
+  assert.equal(skyTargets([q]).mobs[0].items[0].shortfall, 1)
+})
+
+test('an item shared by a turned-in and a never-turned-in quest annotates only the latter', () => {
+  const done = quest({ className: 'Cleric', name: 'Test Done', turnIns: 1, items: [item({ name: 'Sphinx Claw', droppers: [mob('Sphinx')] })] })
+  const open = quest({ className: 'Rogue', name: 'Test Open', items: [item({ name: 'Sphinx Claw', droppers: [mob('Sphinx')] })] })
+  const model = skyTargets([done, open])
+  const entry = model.mobs[0].items[0]
+  assert.equal(entry.shortfall, 1)
+  assert.deepEqual(entry.quests.map((x) => x.questName), ['Test Open'])
+})
+
+// ---------------------------------------------------------------------------
+// 3. Classification — the scrape's own words, never a guess
+// ---------------------------------------------------------------------------
+
+test('a missing Wind Rune lands in the collective entry and never on a mob (AE5, real data)', () => {
+  const rune = QUESTS.flatMap((q) => q.items).find((it) =>
+    it.who.some((w) => w.toLowerCase().startsWith('random drop'))
+  )
+  assert.ok(rune, 'the committed data states random-drop rows')
+  const q = quest({ name: 'Test of Wind', items: [item({ name: rune.name, where: rune.where, who: rune.who, droppers: skyDroppersFor(rune.name, rune.who) })] })
+  const model = skyTargets([q])
+  assert.equal(model.mobs.length, 0)
+  assert.equal(model.randomDrop.length, 1)
+  assert.equal(model.randomDrop[0].name, rune.name)
+  assert.equal(model.randomDrop[0].shortfall, 1)
+})
+
+test('a missing item with no known dropper lands in the no-known-source list (AE6, real data)', () => {
+  // Azarack Blood: posky states a source in words, the catalog resolves nobody (the
+  // poskyDroppers header's measured 3-item remainder).
+  const row = QUESTS.flatMap((q) => q.items).find((it) => it.name === 'Azarack Blood')
+  assert.ok(row, 'Azarack Blood is in the committed data')
+  const droppers = skyDroppersFor(row.name, row.who)
+  assert.equal(droppers.length, 0, 'still unresolved in the committed catalog')
+  const q = quest({ name: 'Test of Azarack', items: [item({ name: row.name, where: row.where, who: row.who, droppers })] })
+  const model = skyTargets([q])
+  assert.equal(model.mobs.length, 0)
+  assert.equal(model.unsourced.length, 1)
+  assert.equal(model.unsourced[0].name, row.name)
+})
+
+test('a real never-turned-in quest yields real kill targets from the committed catalog', () => {
+  const source = QUESTS.find((q) => q.items.some((it) => skyDroppersFor(it.name, it.who).length > 0))
+  assert.ok(source, 'the committed data resolves droppers for some quest')
+  const model = skyTargets([realQuest(source)])
+  assert.ok(model.mobs.length > 0)
+  for (const t of model.mobs) {
+    assert.ok(t.covers >= 1)
+    assert.ok(t.items.length === t.covers)
+    assert.ok(t.items.every((i) => i.shortfall > 0))
+  }
+})
+
+// ---------------------------------------------------------------------------
+// 4. The order is counted
+// ---------------------------------------------------------------------------
+
+test('mobs sort by distinct items covered desc, then name; the order is stable', () => {
+  const twoItems = quest({
+    name: 'Test of Many',
+    items: [
+      item({ name: 'Sky Pearl', droppers: [mob('Gorgalosk')] }),
+      item({ name: 'Sky Sapphire', droppers: [mob('Gorgalosk')] }),
+      item({ name: 'Azarack Feather', droppers: [mob('Azarack')] })
+    ]
+  })
+  const first = skyTargets([twoItems])
+  assert.deepEqual(first.mobs.map((t) => t.mob.name), ['Gorgalosk', 'Azarack'])
+  assert.deepEqual(first.mobs.map((t) => t.covers), [2, 1])
+  // Ties break on name: two mobs each covering one item.
+  const tied = quest({
+    name: 'Test of Ties',
+    items: [
+      item({ name: 'Sky Pearl', droppers: [mob('Gorgalosk')] }),
+      item({ name: 'Azarack Feather', droppers: [mob('Azarack')] })
+    ]
+  })
+  assert.deepEqual(skyTargets([tied]).mobs.map((t) => t.mob.name), ['Azarack', 'Gorgalosk'])
+})
+
+test('items inside a card, and both special lists, read alphabetically', () => {
+  const q = quest({
+    name: 'Test of Order',
+    items: [
+      item({ name: 'Sky Sapphire', droppers: [mob('Gorgalosk')] }),
+      item({ name: 'Azarack Feather', droppers: [mob('Gorgalosk')] })
+    ]
+  })
+  assert.deepEqual(skyTargets([q]).mobs[0].items.map((i) => i.name), ['Azarack Feather', 'Sky Sapphire'])
+})
+
+test('a mob listed on two of one item\'s droppers counts that item once', () => {
+  const dup = mob('Gorgalosk')
+  const q = quest({ name: 'Test of Dupes', items: [item({ name: 'Sky Pearl', droppers: [dup, dup] })] })
+  assert.equal(skyTargets([q]).mobs[0].covers, 1)
+})
+
+test('islands ride per mob from the items it is the target for', () => {
+  const q = quest({
+    name: 'Test of Where',
+    items: [
+      item({ name: 'Sky Pearl', where: 'Island 3', droppers: [mob('Gorgalosk')] }),
+      item({ name: 'Sky Sapphire', where: 'Island 5', droppers: [mob('Gorgalosk')] })
+    ]
+  })
+  assert.deepEqual(skyTargets([q]).mobs[0].islands, ['Island 3', 'Island 5'])
+})

--- a/tests/skyTargets.test.mts
+++ b/tests/skyTargets.test.mts
@@ -254,6 +254,23 @@ test('items inside a card, and both special lists, read alphabetically', () => {
   assert.deepEqual(skyTargets([q]).mobs[0].items.map((i) => i.name), ['Azarack Feather', 'Sky Sapphire'])
 })
 
+test('a random-drop statement from ANY quest classifies the item - never fold-order-dependent', () => {
+  // Quest A states nothing for the item; quest B states the random-drop sentinel. The section
+  // assignment must be the same whichever quest folds first: one quest saying "random drop" is
+  // the scrape speaking, and first-seen-wins would make the pane depend on iteration order.
+  const silent = quest({ className: 'Cleric', name: 'Test Silent', items: [item({ name: 'Wind Rune Ozah', who: [] })] })
+  const stated = quest({
+    className: 'Rogue',
+    name: 'Test Stated',
+    items: [item({ name: 'Wind Rune Ozah', who: ['random drop — any Plane of Sky mob'] })]
+  })
+  for (const order of [[silent, stated], [stated, silent]]) {
+    const model = skyTargets(order)
+    assert.equal(model.randomDrop.length, 1, 'collective entry regardless of fold order')
+    assert.equal(model.unsourced.length, 0)
+  }
+})
+
 test('a mob listed on two of one item\'s droppers counts that item once', () => {
   const dup = mob('Gorgalosk')
   const q = quest({ name: 'Test of Dupes', items: [item({ name: 'Sky Pearl', droppers: [dup, dup] })] })


### PR DESCRIPTION
## Summary

Fixes #30. Players invert the Sky quest tracker in their heads to answer the question they actually walk the islands with - "who do I pull next" - by scrolling the quest list, recalling which mob drops each missing item, and deduplicating mentally. This adds a fifth sub-tab, **Targets**: every Plane of Sky mob still worth killing, deduplicated across quests, each card naming the missing items it can drop, the quests those serve, and its island. The list moves live - looting, turn-ins, and ignoring a quest each re-derive it with nothing reloaded.

> **Stacked on #33.** The need set treats reward-inferred completions as turned in, so this branch builds on the reward-inference commits; until #33 merges, this PR's diff shows both. Reviewing the three `sky targets:` commits plus the review-fix commit gives the clean #30-only view.

## Design

- **The need set is never-turned-in, minus ignored** - the Ready tab's first-time reading (`everTurnedIn`), so a reward-inferred completion is excluded by the same predicate with no special case, and ignoring stays the one flag meaning "never show me this" (decided once, upstream in `useQuestList`).
- **Shortfall aggregates per counting key, never per quest.** `computeQuestProgress` clamps `have` per quest with no cross-quest allocation, so a per-quest filter would read two quests each "satisfied" by the same single held copy. The rule: summed need across the need set, minus the uncapped held count, floored at zero - the best lower bound the data can prove, and there is deliberately no invented per-quest split of the held copies.
- **Classification is the scrape's own words, never a guess**: resolved droppers fold into mob cards (dedupe by page, most-items-covered first - via the same exported comparator the Quests tab's "Kill:" captions use, so the two tabs cannot disagree on a tie); an unresolved item any quest calls a random drop is one collective Wind Rune entry; the three items nothing committed can source are stated as "no known source".
- **The count source rides the pane header** (the Ready tab's JOS-294 argument): the source decides every shortfall this tab renders, so the control is visible where the membership is read.
- **No stored state** - the tab is a pure derivation; the label count reads the same memoized array the pane draws.

## Testing

- `tests/skyTargets.test.mts` - 17 node tests written first and watched fail: the need-set predicate (including reward-inferred exclusion), shared-item aggregation, +N variant folding, classification against the real committed catalog, counted ordering with stable ties, fold-order independence.
- `tests/e2e/sky-targets.e2e.mts` - 12 live-chain checks driven by the proven Beastlord Test of Azarack log lines: ignore on the Quests tab empties the marker item and un-ignore restores it; looting the last items removes the quest before any trade; the turn-in is verified via the quest's own badge before asserting it never rejoins the first-time need set.
- Full unit suite (4,621), typecheck, lint, and all 8 sky e2e specs green; a Tier-1 code-review pass produced 10 findings, 8 fixed in-branch (shared sentinel predicate and comparator moved to `poskyDroppers.ts`, missing hover roster, methodology-caption diet, a vacuous e2e assertion made falsifiable) and 2 accepted with rationale documented in code.

## Post-Deploy Monitoring & Validation

No additional operational monitoring required - a local-only derived view over committed data; no telemetry, storage, or network surface changes.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Fable_5-D97757?logo=claude&logoColor=white)
