### PR TITLE
feat(chat): capture and save player chat

### DIFF
--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -157,7 +157,7 @@ When you switch away from a tab.
 
 | Field | Values | What it means |
 | --- | --- | --- |
-| `view` | `overview` · `combat` · `mobs` · `maps` · `bosses` · `posky` · `alerts` · `leveling` · `loot` · `planner` · `buffs` · `timers` · `gear` · `wishlist` · `character` · `preferences` · `triage` | Which tab. A fixed list of tab names. |
+| `view` | `overview` · `combat` · `mobs` · `maps` · `bosses` · `posky` · `alerts` · `leveling` · `loot` · `planner` · `buffs` · `timers` · `gear` · `wishlist` · `character` · `chat` · `preferences` · `triage` | Which tab. A fixed list of tab names. |
 | `ms` | whole number | How long it was on screen. |
 
 ### `overlayToggle`
@@ -264,7 +264,7 @@ When the app hits an error: the technical details of the failure, so it can be f
 | `componentPath` | at most 8 names joined with > | For an error in the app’s own interface, which of the app’s screen components it came through — the names in this app’s source code, and nothing from the game. |
 | `fingerprint` | 16 hex characters | A hash used to group identical errors together. |
 | `breadcrumbs` | at most 10 × (kind, offset) | What KINDS of log line the app had just read — `damage`, `loot`, `zone` and so on, from a fixed list — and how long before the error each was. The kind only: not the line, not who or what was in it. |
-| `view` | `overview` · `combat` · `mobs` · `maps` · `bosses` · `posky` · `alerts` · `leveling` · `loot` · `planner` · `buffs` · `timers` · `gear` · `wishlist` · `character` · `preferences` · `triage` · `unknown` | Which tab was open. A fixed list. |
+| `view` | `overview` · `combat` · `mobs` · `maps` · `bosses` · `posky` · `alerts` · `leveling` · `loot` · `planner` · `buffs` · `timers` · `gear` · `wishlist` · `character` · `chat` · `preferences` · `triage` · `unknown` | Which tab was open. A fixed list. |
 | `sessionAgeBucket` | bucket index | How long the app had been running. |
 | `mode` | `live` · `replay` | Was it reading your log history, or following it live. |
 | `count` | whole number | How many times this same error happened since the last report. It stops at a hundred per error per run of the app: something that goes wrong over and over reports itself a hundred times and then goes quiet, so one repeating fault cannot bury everything else. |

--- a/src/main/chatArchive.ts
+++ b/src/main/chatArchive.ts
@@ -1,0 +1,110 @@
+// ============================================================================
+// chatArchive.ts — the DURABLE half of chat capture: live chat, appended to a file.
+// ============================================================================
+//
+// The `chat` module (src/main/modules/chat.ts) is the live VIEW; it is rebuilt from the log every
+// launch and writes nothing. This is the SAVE: a bus sink that appends each LIVE chat line to
+// `<userData>/chat/<name_server>.jsonl`, one JSON object per line, so the capture outlives the log
+// the game eventually rotates or the user deletes.
+//
+// LIVE ONLY, on purpose. It ignores replayed (`live:false`) events, so a relaunch does not re-dump
+// the history the scan folds — the log already holds that, and re-appending it every launch would
+// grow the file without bound and duplicate every line. The archive therefore accumulates
+// FORWARD from the moment the feature first runs; it is not a backfill of old logs. (A user who
+// wants the existing history exported already has it: it is the game's own log file.)
+//
+// PRIVACY. This is one of exactly two consumers of `text` (the other is the in-app module), and it
+// writes ONLY to the user's own userData dir — never the network. The feedback slice and the
+// public fixtures never see a `chat` event; they scrub RAW log lines (shared/logScrub.ts). See the
+// ChatEvent header for the whole invariant. Do not add a path that uploads this file.
+//
+// The switch (`getChatCapture`, default ON) is read per line, so toggling it in Preferences takes
+// effect on the next chat line with no relaunch. Cheap: one in-memory electron-store read.
+
+import { createWriteStream, mkdirSync, type WriteStream } from 'fs'
+import { join } from 'path'
+import { USER_DATA } from './channel'
+import { characterId } from './log/config'
+import { logConsoleError, logInfo } from './errorLog'
+import { getChatCapture } from './storeChatCapture'
+import type { LogEvent } from '../shared/logEvents'
+import type { ChatLine } from '../shared/types'
+import type { CharacterRef } from '../shared/types'
+
+/** `<userData>/chat` — created lazily on the first write. */
+function chatDir(): string {
+  return join(USER_DATA, 'chat')
+}
+
+export class ChatArchive {
+  /** The character whose file we are appending to, or null (idle / no character). */
+  private id: string | null = null
+  /** The open append stream for `id`, or null until the first line for this character. */
+  private stream: WriteStream | null = null
+  private dirReady = false
+
+  /**
+   * Point the archive at a character (or null on idle / no-logs). Closes the previous character's
+   * file; the next line for the new one opens theirs. Called from session.ts on every world reset,
+   * beside the `installCharacterName` / roster-self-name injections it belongs with.
+   */
+  setCharacter(ref: CharacterRef | null): void {
+    const next = ref ? characterId(ref) : null
+    if (next === this.id) return
+    this.close()
+    this.id = next
+  }
+
+  /** Bus subscriber. Only LIVE `chat` events, only when the switch is on and a character is set. */
+  onEvent(ev: LogEvent, live: boolean): void {
+    if (!live || ev.kind !== 'chat') return
+    if (this.id === null) return
+    if (!getChatCapture()) return
+    const row: ChatLine = {
+      ts: ev.ts,
+      channel: ev.channel,
+      from: ev.from,
+      self: ev.self,
+      ...(ev.to !== undefined ? { to: ev.to } : {}),
+      ...(ev.chan !== undefined ? { chan: ev.chan } : {}),
+      text: ev.text
+    }
+    this.write(row)
+  }
+
+  private write(row: ChatLine): void {
+    const s = this.ensureStream()
+    if (!s) return
+    s.write(JSON.stringify(row) + '\n')
+  }
+
+  /** Open (once) the append stream for the current character. Null if there is no character or the
+   *  open failed — a failed archive must never take down the tail, so every error is logged and
+   *  swallowed. */
+  private ensureStream(): WriteStream | null {
+    if (this.stream) return this.stream
+    if (this.id === null) return null
+    try {
+      if (!this.dirReady) {
+        mkdirSync(chatDir(), { recursive: true })
+        this.dirReady = true
+      }
+      const path = join(chatDir(), `${this.id}.jsonl`)
+      const s = createWriteStream(path, { flags: 'a' })
+      s.on('error', (err) => logConsoleError('[everquest-companion] chat archive write error', err))
+      this.stream = s
+      logInfo(`[everquest-companion] Chat archive: appending to ${path}`)
+      return s
+    } catch (err) {
+      logConsoleError('[everquest-companion] chat archive open error', err)
+      return null
+    }
+  }
+
+  private close(): void {
+    if (this.stream) {
+      this.stream.end()
+      this.stream = null
+    }
+  }
+}

--- a/src/main/ipc/chat.ts
+++ b/src/main/ipc/chat.ts
@@ -1,0 +1,16 @@
+// IPC: the chat-capture switch (storeChatCapture.ts) — does the Chat viewer also SAVE to a file.
+//
+// Two channels, no session side effect and none needed. chatArchive.ts reads `getChatCapture()`
+// per line, so a flip here is seen by the very next chat line with no relaunch and nothing to
+// apply — unlike uiScale (which must repaint the window) this handler only stores. The value is a
+// plain boolean coerced at the handler, on the `sounds:getData` rule: today's only caller is the
+// app's own toggle, but a renderer must not be able to store a non-boolean.
+
+import { ipcMain } from 'electron'
+import { IPC } from '../../shared/ipc'
+import { getChatCapture, setChatCapture } from '../storeChatCapture'
+
+export function registerChatIpc(): void {
+  ipcMain.handle(IPC.chatCaptureGet, () => getChatCapture())
+  ipcMain.handle(IPC.chatCaptureSet, (_e, value: unknown) => setChatCapture(value === true))
+}

--- a/src/main/ipc/index.ts
+++ b/src/main/ipc/index.ts
@@ -20,6 +20,7 @@ import { registerResistIpc } from './resist'
 import { registerRespawnIpc } from './respawn'
 import { registerCharacterIpc } from './character'
 import { registerCharacterSheetIpc } from './characterSheet'
+import { registerChatIpc } from './chat'
 import { registerClipboardIpc } from './clipboard'
 import { registerComboIpc } from './combo'
 import { registerDevIpc } from './dev'
@@ -76,6 +77,7 @@ export function registerIpc(): void {
   registerConCardIpc()
   registerTrayIpc()
   registerClipboardIpc()
+  registerChatIpc()
   registerFeedbackIpc()
   registerTelemetryIpc()
   registerPerfIpc()

--- a/src/main/log/parseChat.ts
+++ b/src/main/log/parseChat.ts
@@ -1,0 +1,208 @@
+// ============================================================================
+// parseChat.ts — the chat pass. NOT part of the single-event cascade (parser.ts).
+// ============================================================================
+//
+// The cascade returns ONE event per line, and several chat lines are ALREADY something else to it:
+// `<Name> tells the group, '…'` is a `group` event (parseGroup.ts's roster-recovery signal). Chat
+// is cross-cutting — the SAME line is both a membership fact and a message — so it cannot ride the
+// cascade, which is why this is a separate pass the feeders call alongside `parseEvent`, emitting
+// an ADDITIONAL `chat` event onto the same bus. See the ChatEvent header in shared/logEvents.ts.
+//
+// WHAT THIS CAPTURES, and why exactly this set. Every directed/social channel whose speaker is
+// UNAMBIGUOUSLY a player — the families `shared/logScrub.ts` enumerates — MINUS the one it cannot
+// tell from a mob. A mob cannot /tell, /guildsay, /gsay, /rsay, /ooc, /auction or /shout, and its
+// name is multi-word (`a rock golem`) so it fails the single-token NAME anyway; but a mob DOES
+// `<Name> says, '…'`, and single-proper-name NPCs (`Setikan says`) are indistinguishable from
+// players by shape. So third-party `say` is DROPPED and only the first-person `You say, '…'` is
+// kept (unambiguously the tailed character). This is the same line logScrub draws, for the same
+// reason, from the other side: it drops all of this to keep it out of a public artifact; we keep
+// the player half to show and save it locally.
+//
+// MEASURED — whole-log sweep of eqlog_Jibblits_rivervale, 176,296 lines (the shapes below are the
+// ones this log actually printed; `raid`/`shout` did not occur and are written from EQ's own
+// wording of the channels present, tested from synthetic lines and LABELED, per the awaiting-sample
+// law in AGENTS.md):
+//
+//   <Name> tells <Chan>:<n>, '…'      3468 + 2456   → channel  (General1:1, General:1)
+//   <Name> tells the guild, '…'         270         → guild
+//   <Name> tells the group, '…'          88         → group
+//   You say to your guild, '…'           68         → guild  (self)
+//   You tell your party, '…'             58         → group  (self)
+//   You say, '…'                         31         → say    (self)
+//   <Name> told <name>, '…'              29         → tell   (self, outbound; target may be typed lowercase)
+//   <Name> tells you, '…'                26         → tell   (inbound)
+//   You tell <Chan>:<n>, '…'              7         → channel (self)
+//   <Name> says out of character, '…'     3         → ooc
+//   <Name> auctions, '…'                  2         → auction
+//
+// THE PET FAMILIES ARE NOT AT RISK. logScrub carves out three NPC-pet shapes it must keep in a
+// fixture (`<Pet> told you, 'Attacking … Master.'`, the six pet says, `<Pet> says, 'My leader is
+// …'`). None can reach us: our inbound tell matches the PRESENT tense `tells you` (a player tell),
+// never the pet-claim's `told you`; and we capture no third-party `says` at all, which is every
+// other pet line. So no NPC line is ever saved as a person's chat, with no carve-out needed here.
+//
+// PERF. The whole pass is gated by ONE substring probe — a line with no `, '` is not chat and not
+// anything else with quoted speech — so the 96% of lines that are combat/heal/loot pay a single
+// `includes` and never reach a regex. This mirrors the cascade's own hot-path discipline.
+
+import type { ChatChannel, ChatEvent } from '../../shared/logEvents'
+import { parseLine } from './parser'
+
+/** A player name subject: one token, with the backtick/apostrophe/hyphen EQ allows. Single-token
+ *  on purpose (as in parseGroup.ts): a player's name never has a space, and the anchor keeps a mob
+ *  name (`a rock golem`) or a quoted sentence from satisfying it. Case is not constrained — an
+ *  outbound tell's target is printed however it was typed (`You told ahrima, …`). */
+const NAME = "[A-Za-z][A-Za-z`'-]*"
+
+/** A custom chat channel with a slot: a name then `:<digits>`, e.g. `General:1`, `General1:1`. The
+ *  digit slot is what tells a channel apart from `tells you` / `tells the guild` — those can never
+ *  match this, so channel order in the table is free. */
+const CHAN = '[A-Za-z][A-Za-z0-9]*:[0-9]+'
+
+/** The message runs to the LAST `'` on the line: EQ does not escape an apostrophe inside a
+ *  message, so `'(.*)'$` greedily takes `don't` and leaves the true closing quote for the anchor. */
+interface Shape {
+  re: RegExp
+  channel: ChatChannel
+  self: boolean
+  /** Pull `{ from, to, chan, text }` out of the match for this shape. */
+  build: (m: RegExpMatchArray) => { from: string; to?: string; chan?: string; text: string }
+}
+
+// Inbound shapes NAME the speaker (capture 1). Outbound shapes are first-person (`from: 'You'`).
+// Order is not load-bearing — every regex is anchored at both ends and the channel token's digit
+// slot disjoins the one overlap — but the table reads inbound-then-outbound, grouped by channel.
+const SHAPES: readonly Shape[] = [
+  // ---- inbound (someone else) ----
+  {
+    re: new RegExp(`^(${NAME}) tells you, '(.*)'$`),
+    channel: 'tell',
+    self: false,
+    build: (m) => ({ from: m[1], text: m[2] })
+  },
+  {
+    re: new RegExp(`^(${NAME}) tells the guild, '(.*)'$`),
+    channel: 'guild',
+    self: false,
+    build: (m) => ({ from: m[1], text: m[2] })
+  },
+  {
+    re: new RegExp(`^(${NAME}) tells the group, '(.*)'$`),
+    channel: 'group',
+    self: false,
+    build: (m) => ({ from: m[1], text: m[2] })
+  },
+  {
+    // UNVERIFIED — absent from this log; standard EQ raid wording (see the header).
+    re: new RegExp(`^(${NAME}) tells the raid, '(.*)'$`),
+    channel: 'raid',
+    self: false,
+    build: (m) => ({ from: m[1], text: m[2] })
+  },
+  {
+    re: new RegExp(`^(${NAME}) says out of character, '(.*)'$`),
+    channel: 'ooc',
+    self: false,
+    build: (m) => ({ from: m[1], text: m[2] })
+  },
+  {
+    re: new RegExp(`^(${NAME}) auctions, '(.*)'$`),
+    channel: 'auction',
+    self: false,
+    build: (m) => ({ from: m[1], text: m[2] })
+  },
+  {
+    // UNVERIFIED — absent from this log; standard EQ /shout wording.
+    re: new RegExp(`^(${NAME}) shouts, '(.*)'$`),
+    channel: 'shout',
+    self: false,
+    build: (m) => ({ from: m[1], text: m[2] })
+  },
+  {
+    re: new RegExp(`^(${NAME}) tells (${CHAN}), '(.*)'$`),
+    channel: 'channel',
+    self: false,
+    build: (m) => ({ from: m[1], chan: m[2], text: m[3] })
+  },
+  // ---- outbound (the tailed character) ----
+  {
+    re: new RegExp(`^You told (${NAME}), '(.*)'$`),
+    channel: 'tell',
+    self: true,
+    build: (m) => ({ from: 'You', to: m[1], text: m[2] })
+  },
+  {
+    re: /^You say to your guild, '(.*)'$/,
+    channel: 'guild',
+    self: true,
+    build: (m) => ({ from: 'You', text: m[1] })
+  },
+  {
+    re: /^You tell your party, '(.*)'$/,
+    channel: 'group',
+    self: true,
+    build: (m) => ({ from: 'You', text: m[1] })
+  },
+  {
+    // UNVERIFIED — standard EQ raid wording (see the header).
+    re: /^You tell your raid, '(.*)'$/,
+    channel: 'raid',
+    self: true,
+    build: (m) => ({ from: 'You', text: m[1] })
+  },
+  {
+    re: /^You say out of character, '(.*)'$/,
+    channel: 'ooc',
+    self: true,
+    build: (m) => ({ from: 'You', text: m[1] })
+  },
+  {
+    re: /^You auction, '(.*)'$/,
+    channel: 'auction',
+    self: true,
+    build: (m) => ({ from: 'You', text: m[1] })
+  },
+  {
+    // UNVERIFIED — standard EQ /shout wording.
+    re: /^You shout, '(.*)'$/,
+    channel: 'shout',
+    self: true,
+    build: (m) => ({ from: 'You', text: m[1] })
+  },
+  {
+    re: new RegExp(`^You tell (${CHAN}), '(.*)'$`),
+    channel: 'channel',
+    self: true,
+    build: (m) => ({ from: 'You', chan: m[1], text: m[2] })
+  },
+  {
+    // FIRST-PERSON SAY ONLY. Third-party `<Name> says, '…'` is deliberately absent — mob-ambiguous
+    // (see the header). Anchored `^You say, '` so `You say to your guild,` / `You say out of
+    // character,` (both begin `You say `) can never fall here.
+    re: /^You say, '(.*)'$/,
+    channel: 'say',
+    self: true,
+    build: (m) => ({ from: 'You', text: m[1] })
+  }
+]
+
+/**
+ * One line → a `chat` event, or null when the line is not player chat.
+ *
+ * `seq` is the bus sequence this additional event claims (the feeder increments its shared counter
+ * for it exactly as it does for a primary event). Returns null cheaply for the overwhelming
+ * majority of lines via the `, '` probe before `parseLine` (which reads the timestamp) runs.
+ */
+export function parseChat(raw: string, seq: number): ChatEvent | null {
+  if (!raw.includes(", '")) return null
+  const line = parseLine(raw)
+  if (!line) return null
+  const { ts, text } = line
+  for (const s of SHAPES) {
+    const m = s.re.exec(text)
+    if (!m) continue
+    const parts = s.build(m)
+    return { kind: 'chat', channel: s.channel, self: s.self, ts, seq, raw, ...parts }
+  }
+  return null
+}

--- a/src/main/log/scanHistory.ts
+++ b/src/main/log/scanHistory.ts
@@ -1,6 +1,7 @@
 import { createReadStream } from 'fs'
 import { stat } from 'fs/promises'
 import { parseEvent } from './parser'
+import { parseChat } from './parseChat'
 import { createSlicer, type Slicer } from './replaySlicer'
 import type { LogBus } from './bus'
 
@@ -215,6 +216,16 @@ export async function scanLog(
     if (!ev) return // not a log line at all (no timestamp)
     seq++
     bus.emit(ev, false)
+    // CHAT rides its own pass beside the cascade and emits an ADDITIONAL event claiming the next
+    // seq (see parseChat.ts). live:false — the historical scan folds it into the chat MODULE's
+    // snapshot (so the viewer opens with history) but the archive ignores replayed events, so no
+    // old line is re-written to disk. A non-chat line never reaches the regex battery: the `, '`
+    // probe inside parseChat rules it out for the ~96% that carry no quoted speech.
+    const chat = parseChat(raw, seq)
+    if (chat) {
+      seq++
+      bus.emit(chat, false)
+    }
   }
 
   // Byte-accurate line splitting (see SplitState / consumeChunk).

--- a/src/main/modules/chat.ts
+++ b/src/main/modules/chat.ts
@@ -1,0 +1,70 @@
+// chat module — the in-app chat log. Folds the `chat` event (parseChat.ts) into an append-only
+// history the viewer hydrates and rides deltas on, exactly like `loot`: a delta carries the rows
+// appended since the last flush and the renderer concats them.
+//
+// It is the LIVE VIEW half of the feature; the DURABLE half is chatArchive.ts, a separate bus sink
+// that writes live lines to disk. They are split for the same reason loot's history and the loot
+// FILE would be: this module's history is rebuilt from the log on every launch (the log IS its
+// store, so a snapshot always carries the whole thing), while the archive exists precisely to
+// outlive the log the game rotates. This module writes nothing to disk.
+//
+// EPOCH. Chat before the character-rebirth boundary belongs to a dead same-name character; clear
+// the history on `epoch` so the viewer shows only the current character's, matching every other
+// character-scoped module (see loot.ts).
+//
+// PRIVACY. `text` is a person's words; this module keeps it in memory and hands it to the renderer
+// over `module:delta` (the user's own window) and NOWHERE else. See the ChatEvent header.
+//
+// ponytail: history is uncapped, like loot's. A months-long log yields a few tens of thousands of
+// chat rows — fine in memory. If a whale's log ever makes this heavy, cap it here (keep the last N,
+// drop from the front) — the viewer already treats the snapshot as "what there is", not "all there
+// ever was".
+
+import type { EqModule } from './types'
+import type { LogEvent } from '../../shared/logEvents'
+import type { ChatDelta, ChatLine, ChatSnap } from '../../shared/types'
+
+export class ChatModule implements EqModule<ChatSnap, ChatDelta> {
+  readonly id = 'chat'
+  private lines: ChatLine[] = []
+  private seq = 0
+  private pending: ChatLine[] = []
+
+  reset(): void {
+    this.lines = []
+    this.seq = 0
+    this.pending = []
+  }
+
+  onEvent(ev: LogEvent): void {
+    this.seq = ev.seq
+    if (ev.kind === 'epoch') {
+      this.lines = []
+      this.pending = []
+      return
+    }
+    if (ev.kind !== 'chat') return
+    const row: ChatLine = {
+      ts: ev.ts,
+      channel: ev.channel,
+      from: ev.from,
+      self: ev.self,
+      to: ev.to,
+      chan: ev.chan,
+      text: ev.text
+    }
+    this.lines.push(row)
+    this.pending.push(row)
+  }
+
+  snapshot(): { seq: number; state: ChatSnap } {
+    return { seq: this.seq, state: this.lines }
+  }
+
+  flushDelta(): { seq: number; delta: ChatDelta } | null {
+    if (this.pending.length === 0) return null
+    const delta: ChatDelta = { appended: this.pending }
+    this.pending = []
+    return { seq: this.seq, delta }
+  }
+}

--- a/src/main/modules/wiring.ts
+++ b/src/main/modules/wiring.ts
@@ -28,6 +28,7 @@ import { MessageOverlayMiner, type OverlaySeed } from '../data/messageOverlay'
 import { ComboModule } from './combo'
 import { RosterModule } from './roster'
 import { LootModule } from './loot'
+import { ChatModule } from './chat'
 import { TurnInsModule } from './turnins'
 import { ClassUnlocksModule } from './classUnlocks'
 import { KillsModule } from './kills'
@@ -94,6 +95,7 @@ export interface ModuleWiring {
   combo: ComboModule
   roster: RosterModule
   loot: LootModule
+  chat: ChatModule
   turnIns: TurnInsModule
   classUnlocks: ClassUnlocksModule
   kills: KillsModule
@@ -156,6 +158,11 @@ export function createModules(deps: ModuleWiringDeps = {}): ModuleWiring {
   // lines the log prints outright.
   const roster = new RosterModule()
   const loot = new LootModule()
+  // The chat log (the in-app viewer half of chat capture). Folds the `chat` event parseChat.ts
+  // emits beside the cascade into an append-only history, exactly like loot. Position is free: it
+  // folds one event kind (`chat`) no other module reads, and nothing reads its state within a
+  // delivery. The DURABLE half is chatArchive.ts, a bus sink pipeline.ts wires — not a module.
+  const chat = new ChatModule()
   const turnIns = new TurnInsModule()
   // WHICH CLASSES THIS CHARACTER MAY RUN AS A PRIMARY (JOS-148) — the observed half of the Sky
   // tab's class-unlock reading, folded from the one line that states an unlock outright. Beside
@@ -243,6 +250,7 @@ export function createModules(deps: ModuleWiringDeps = {}): ModuleWiring {
     combo,
     roster,
     loot,
+    chat,
     turnIns,
     classUnlocks,
     kills,
@@ -269,6 +277,9 @@ export function createModules(deps: ModuleWiringDeps = {}): ModuleWiring {
       combo,
       roster,
       loot,
+      // Free position: folds only `chat` (which nothing else reads) and no module reads its state
+      // within a delivery. Beside loot because it is the same append-only history shape.
+      chat,
       turnIns,
       // Position is free: it folds one line kind no other module reads, and nothing reads its
       // state within a delivery. Beside turnIns because that is where a reader looks for it.

--- a/src/main/pipeline.ts
+++ b/src/main/pipeline.ts
@@ -29,6 +29,7 @@ import { spellCorrectionsReport, spellPlaceholdersReport, spellRemovalsReport } 
 // beside its three siblings because the pass has two callers over one catalog — see that file.
 import { spellEraReport } from './data/spellEra'
 import { CombatEngine } from './combat/engine'
+import { ChatArchive } from './chatArchive'
 import { ModuleRegistry } from './modules/registry'
 import { createModules } from './modules/wiring'
 import { resistLedgerSeam } from './resist/store'
@@ -287,6 +288,13 @@ combat.setRoster(rosterModule)
 // costs a rebuild.
 combat.setCombo(comboModule)
 bus.subscribe((ev, live) => combat.ingestEvent(ev, live))
+// THE DURABLE HALF OF CHAT CAPTURE — a pure bus sink that appends LIVE `chat` lines to a file so
+// the save outlives the game's log rotation (src/main/chatArchive.ts). Order is free: it reads no
+// other consumer's state and pushes nothing back onto the bus. It ignores replayed events, so this
+// subscription does nothing during the historical scan; session.ts points it at the active
+// character on every world reset. The in-app VIEWER is the `chat` MODULE, registered above.
+export const chatArchive = new ChatArchive()
+bus.subscribe((ev, live) => chatArchive.onEvent(ev, live))
 // Item-knowledge prefetch (Task #53): when a LIVE loot event arrives, warm the
 // "what's this for" cache in the background (throttled by itemLookup's serialized queue
 // + persistent cache) so the answer is ready by the time the user clicks the item. LIVE

--- a/src/main/session.ts
+++ b/src/main/session.ts
@@ -24,6 +24,7 @@ import {
 } from './log/config'
 import { Tailer } from './log/Tailer'
 import { parseEvent, parseLine } from './log/parser'
+import { parseChat } from './log/parseChat'
 import { installCharacterName } from './log/rulesets'
 import { scanLog } from './log/scanHistory'
 import { formatTailIoSummary, takeTailIoSummary } from './log/tailIoStats'
@@ -35,6 +36,7 @@ import {
   bus,
   buffsModule,
   characterModule,
+  chatArchive,
   combat,
   epoch,
   killsModule,
@@ -177,6 +179,9 @@ export async function applyEqDirChange(): Promise<EqConfig> {
     // No character ⇒ no self-`/who` row is identifiable. Clear the name rather than let a
     // stale one attribute the next log's rows to the character we just stopped tailing.
     installCharacterName(undefined)
+    // …and close the chat archive's file: with no character there is nothing to append, and a live
+    // line that somehow arrived must not land in the file of the character we just left.
+    chatArchive.setCharacter(null)
     // Every window that folds a module, not just the main one (JOS-172): an overlay left open
     // over an install whose log went away must empty with everything else.
     sendWorldRebuilt(null)
@@ -281,6 +286,11 @@ function resetWorldFor(ref: CharacterRef): void {
   // the character on their own group roster. Same injection path, same instant, for the same
   // reason: it must be in place before the scan replay folds the first burst.
   rosterModule.setSelfName(ref.name)
+  // Point the durable chat archive at this character's file (chatArchive.ts). Beside the other
+  // per-character injections here for the same reason they are: everything that must know "whose log
+  // this now is" learns it in one place, before the scan replay — though the archive itself ignores
+  // that replay and only writes the live tail.
+  chatArchive.setCharacter(ref)
   combat.reset()
   // Inject the player's own name (we know it from the ref) BEFORE the scan replay,
   // so incoming self-heals ("You healed <Name> for N") attribute from the first
@@ -327,6 +337,16 @@ function startTailer(logPath: string, startOffset: number): void {
       seq++
       noteParsed(1)
       bus.emit(ev, true)
+    }
+    // CHAT is cross-cutting, so it rides its OWN pass beside the cascade and is emitted as an
+    // ADDITIONAL event claiming the next seq (see the ChatEvent header / parseChat.ts). A chat line
+    // always carries a timestamp, so `parseEvent` above already produced its primary event (a
+    // `group` tell, or `unknown`); this adds the message alongside it. Live, so the archive saves it
+    // and the viewer updates.
+    const chat = parseChat(raw, seq)
+    if (chat) {
+      seq++
+      bus.emit(chat, true)
     }
     notifyCombatActivity() // FIX 4: throttled push so the meter refreshes sub-second
   })

--- a/src/main/storeChatCapture.ts
+++ b/src/main/storeChatCapture.ts
@@ -1,0 +1,24 @@
+// storeChatCapture.ts — the persisted half of "the Chat tab also saves to a file" (chat capture).
+//
+// Another module through the `settingsStore` door (uiScale.ts was the first, storeCloseToTray.ts a
+// sibling): store.ts sits at the 400-code-line factoring ceiling, so an accessor pair lives beside
+// it rather than in it. A single boolean — there is no blob to normalize, so unlike closeToTray
+// there is no shared normalizer; the default IS the normalization.
+//
+// ADDITIVE + OPTIONAL ⇒ NO SCHEMA BUMP, NO MIGRATION, and it DEFAULTS TO ON — the storeShape.ts
+// key comments carry the full argument (the `closeToTray` carve-out: a default-on additive key
+// needs no migration because nothing downstream must tell a stored default from an inherited one).
+
+import { settingsStore } from './store'
+
+/** Is the durable chat archive on? Absent ⇒ ON (the shipped behaviour of the feature). */
+export function getChatCapture(): boolean {
+  return settingsStore.get('chatCapture') ?? true
+}
+
+/** Persist the switch; returns what was stored, so the Preferences toggle renders main's answer
+ *  rather than assuming its request landed. */
+export function setChatCapture(enabled: boolean): boolean {
+  settingsStore.set('chatCapture', enabled)
+  return enabled
+}

--- a/src/main/storeShape.ts
+++ b/src/main/storeShape.ts
@@ -195,6 +195,24 @@ export interface StoreShape {
    * ceiling.
    */
   closeToTray?: CloseToTrayPrefs
+  /**
+   * WHETHER THE CHAT VIEWER ALSO SAVES LIVE CHAT TO A FILE (chat capture). A single boolean:
+   * `true` ⇒ chatArchive.ts appends each live chat line to `<userData>/chat/<name_server>.jsonl`
+   * so it outlives the log the game rotates; `false` ⇒ the in-app Chat viewer still works (it is
+   * rebuilt from the log every launch), but nothing is written to disk.
+   *
+   * DEFAULTS TO ON — the feature the tab exists for is saving chat, and the same words already sit
+   * uncensored in the game's own log on the same disk, so the durable copy adds reach, not
+   * exposure. (A maintainer who prefers the more conservative default flips the `?? true` in
+   * storeChatCapture.ts to `?? false`; nothing else changes.) It carries NO content off the
+   * machine either way — see the ChatEvent header.
+   *
+   * ADDITIVE + OPTIONAL ⇒ no schema bump, no migration — the `closeToTray` carve-out above. Like
+   * it, the default is ON, and for the same reason it needs no migration: nothing downstream ever
+   * has to tell a stored default from an inherited one — every reader just defaults. Accessor in
+   * `storeChatCapture.ts` (store.ts is at its line ceiling).
+   */
+  chatCapture?: boolean
   // `eqExclusiveNoticeDismissedVersion` (JOS-368) LIVED HERE and was removed by JOS-375 with the
   // note it remembered — the game's Fullscreen setting is a borderless window on this client, so
   // the advice could never be true. Migration 12 → 13 deletes the key from any store that has it.

--- a/src/preload/windows.ts
+++ b/src/preload/windows.ts
@@ -55,6 +55,14 @@ export const windowsApi = {
     return () => ipcRenderer.removeListener(IPC.onCloseToTray, listener)
   },
 
+  // ---- does the Chat tab also SAVE chat to a file (chat capture; storeChatCapture.ts) ----
+  // Here rather than in a bridge of its own for the same reason closeToTray is: index.ts is at the
+  // 400-line ceiling and this is a preference read/set pair. A plain boolean, one control, no push.
+  /** Is live chat being saved to a file? ON on every install that has not turned it off. */
+  getChatCapture: (): Promise<boolean> => ipcRenderer.invoke(IPC.chatCaptureGet),
+  /** Set it; chatArchive.ts obeys the new value on the next chat line, no relaunch. */
+  setChatCapture: (enabled: boolean): Promise<boolean> => ipcRenderer.invoke(IPC.chatCaptureSet, enabled),
+
   // ---- the floating overlays' open-state (Task #52; per-kind in Task #54) ----
   /** Toggle a kind's overlay window; resolves to the resulting open-state. */
   toggleOverlay: (kind: OverlayKind): Promise<boolean> => ipcRenderer.invoke(IPC.overlayToggle, kind),

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -18,6 +18,7 @@ import { useAppRouting, usePrefsRouting, type AppRouting, type PrefsRouting } fr
 import { useBackFallback } from './appBack'
 import PoskyView from './features/posky/PoskyView'
 import LootView from './features/loot/LootView'
+import ChatView from './features/chat/ChatView'
 import LevelingView from './features/leveling/LevelingView'
 import PlannerView from './features/planner/PlannerView'
 import GearView from './features/gear/GearView'
@@ -159,6 +160,9 @@ function PlainView({
           by the fold the character switch kicks off. */}
       {view === 'timers' && <TimersView key={viewKey} />}
       {view === 'alerts' && <AlertsView key={viewKey} {...{ onOpenVoicePrefs, onOpenOverlayPrefs }} />}
+      {/* CHAT is a character's log, so it is keyed like the rest: the remount `key` is the whole
+          character contract, and the chat module re-hydrates under the new one. */}
+      {view === 'chat' && <ChatView key={viewKey} />}
       {/* CHARACTER (JOS-45, released JOS-327). It sits HERE, below the no-characters gate, and not
           beside the triage branch: unlike triage this tab reads the game log (name, level, loadout)
           and the character's own inventory dump, so a machine with no EverQuest install has nothing

--- a/src/renderer/src/appViews.ts
+++ b/src/renderer/src/appViews.ts
@@ -14,6 +14,7 @@ export type View =
   | 'alerts'
   | 'leveling'
   | 'loot'
+  | 'chat'
   | 'planner'
   // The GEAR PLANNER's search surface (JOS-284) — the candidate index over every equippable item.
   // It was a top-level nav row of its own until JOS-324; it is now the FIRST TAB of the gear area
@@ -61,6 +62,7 @@ export const VIEW_LABELS: Record<View, string> = {
   alerts: 'Alerts',
   leveling: 'Leveling',
   loot: 'Loot',
+  chat: 'Chat',
   // THE TAB IS CALLED EXALTATIONS (owner, 2026-08-06, JOS-42). "Planner" described what the
   // surface does for us; "Exaltations" names the game system the player came here about. The
   // `planner` view id, its route, its `eq.planner.*` keys and every `planner-*` testid are
@@ -90,6 +92,7 @@ const KNOWN_VIEWS: View[] = [
   'alerts',
   'leveling',
   'loot',
+  'chat',
   'planner',
   'gear',
   'wishlist',

--- a/src/renderer/src/components/NavDrawer.tsx
+++ b/src/renderer/src/components/NavDrawer.tsx
@@ -7,6 +7,7 @@ import ReceiptLongIcon from '@mui/icons-material/ReceiptLong'
 import TrendingUpIcon from '@mui/icons-material/TrendingUp'
 import EmojiEventsIcon from '@mui/icons-material/EmojiEvents'
 import NotificationsActiveIcon from '@mui/icons-material/NotificationsActive'
+import ChatIcon from '@mui/icons-material/Chat'
 import TimerIcon from '@mui/icons-material/Timer'
 import AutoFixHighIcon from '@mui/icons-material/AutoFixHigh'
 import PetsIcon from '@mui/icons-material/Pets'
@@ -100,6 +101,9 @@ const ROWS: NavRow[] = [
   { view: 'bosses', icon: <EmojiEventsIcon /> },
   { view: 'posky', icon: <ShieldMoonIcon /> },
   { view: 'alerts', icon: <NotificationsActiveIcon /> },
+  // Chat sits beside Alerts: both are the log's WORDS rather than its numbers — one you subscribe
+  // to as rules, the other you read as a feed.
+  { view: 'chat', icon: <ChatIcon /> },
   { view: 'leveling', icon: <TrendingUpIcon /> },
   { view: 'buffs', icon: <AutoFixHighIcon /> },
   // Respawn clocks (JOS-194) sit beside Buffs because both tabs are the same shape of answer —

--- a/src/renderer/src/features/chat/ChatView.tsx
+++ b/src/renderer/src/features/chat/ChatView.tsx
@@ -1,0 +1,163 @@
+// chat/ChatView.tsx — THE CHAT LOG. The one tab that shows people's words.
+//
+// WHAT THIS TAB IS. Every player chat line this character's log holds — tells, guild, group, the
+// custom channels, OOC, auction, plus your own /say — oldest first, filterable by channel and
+// searchable. It hydrates from the `chat` module (rebuilt from the log every launch) and rides
+// deltas live, exactly like Loot. The SAVE half — the same lines appended to a file that survives
+// the game rotating its log — is chatArchive.ts in main; the switch for it is in Preferences.
+//
+// WHY /say READS ONE-SIDED. Only YOUR /say appears: a third party's `<Name> says` is
+// indistinguishable from a mob's by shape, so parseChat.ts drops it rather than log "a rock golem"
+// as a person. The empty-state and this note are where a user meets that limit; the parseChat
+// header is where it is argued.
+//
+// THE LIST IS ITS OWN SCROLLER (AGENTS.md UI conventions): a chat log grows without bound, so it
+// lives in a bounded box rather than growing the page.
+
+import { type JSX, useMemo, useState } from 'react'
+import { Box, Chip, Stack, TextField, Typography } from '@mui/material'
+import ChatIcon from '@mui/icons-material/Chat'
+import type { ChatChannel, ChatLine } from '@shared/types'
+import { useChatHistory } from './useChatHistory'
+
+/** Display name + a stable color per channel. The color is the only thing distinguishing a wall of
+ *  one-line messages at a glance, so each channel keeps its own. */
+const CHANNEL_META: Record<ChatChannel, { label: string; color: string }> = {
+  tell: { label: 'Tell', color: '#c586c0' },
+  group: { label: 'Group', color: '#4ec9b0' },
+  guild: { label: 'Guild', color: '#4fc1ff' },
+  raid: { label: 'Raid', color: '#ce9178' },
+  ooc: { label: 'OOC', color: '#9cdcfe' },
+  auction: { label: 'Auction', color: '#dcdcaa' },
+  shout: { label: 'Shout', color: '#f48771' },
+  say: { label: 'Say', color: '#b5cea8' },
+  channel: { label: 'Channel', color: '#808080' }
+}
+
+/** The channels, in the order the filter bar shows them. */
+const CHANNEL_ORDER: ChatChannel[] = ['tell', 'group', 'guild', 'raid', 'channel', 'ooc', 'auction', 'shout', 'say']
+
+/** How a line names its speaker/target: `You → Bob` for a tell you sent, `[General:1] Zed` for a
+ *  custom channel, `Bob` otherwise. */
+function speaker(l: ChatLine): string {
+  if (l.channel === 'channel' && l.chan) return `[${l.chan}] ${l.from}`
+  if (l.channel === 'tell' && l.self && l.to) return `You → ${l.to}`
+  return l.from
+}
+
+function fmtTime(ts: number): string {
+  return new Date(ts).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' })
+}
+
+function NoChat({ filtered }: { filtered: boolean }): JSX.Element {
+  return (
+    <Stack alignItems="center" justifyContent="center" spacing={1.5} sx={{ py: 6, color: 'text.secondary' }}>
+      <ChatIcon sx={{ fontSize: 44, opacity: 0.6 }} />
+      <Typography variant="body2" data-testid="chat-empty" sx={{ maxWidth: 480, textAlign: 'center' }}>
+        {filtered
+          ? 'No chat matches those filters.'
+          : "No chat captured yet. Tells, guild, group, channels, OOC and auction from your log show up here, plus your own /say. (Other players' /say is left out: the game prints it exactly like a monster's, so it can't be told apart.)"}
+      </Typography>
+    </Stack>
+  )
+}
+
+export default function ChatView(): JSX.Element {
+  const history = useChatHistory()
+  // All channels on by default. A channel toggles off when its chip is clicked.
+  const [off, setOff] = useState<Set<ChatChannel>>(() => new Set())
+  const [query, setQuery] = useState('')
+
+  const toggle = (c: ChatChannel): void =>
+    setOff((prev) => {
+      const next = new Set(prev)
+      if (next.has(c)) next.delete(c)
+      else next.add(c)
+      return next
+    })
+
+  const rows = useMemo(() => {
+    const q = query.trim().toLowerCase()
+    return history.filter((l) => {
+      if (off.has(l.channel)) return false
+      if (q === '') return true
+      return l.text.toLowerCase().includes(q) || l.from.toLowerCase().includes(q)
+    })
+  }, [history, off, query])
+
+  const filtering = off.size > 0 || query.trim() !== ''
+
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', height: '100%', minHeight: 0, p: 2, gap: 1.5 }}>
+      <Stack direction="row" alignItems="center" spacing={1} flexWrap="wrap" useFlexGap>
+        {CHANNEL_ORDER.map((c) => {
+          const meta = CHANNEL_META[c]
+          const active = !off.has(c)
+          return (
+            <Chip
+              key={c}
+              label={meta.label}
+              size="small"
+              onClick={() => toggle(c)}
+              data-testid={`chat-filter-${c}`}
+              variant={active ? 'filled' : 'outlined'}
+              sx={{
+                bgcolor: active ? meta.color : 'transparent',
+                color: active ? '#000' : 'text.secondary',
+                borderColor: meta.color,
+                fontWeight: 600
+              }}
+            />
+          )
+        })}
+        <Box sx={{ flexGrow: 1 }} />
+        <TextField
+          size="small"
+          placeholder="Search chat..."
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          data-testid="chat-search"
+          sx={{ minWidth: 200 }}
+        />
+      </Stack>
+
+      <Typography variant="caption" color="text.secondary">
+        {rows.length.toLocaleString()} {rows.length === 1 ? 'line' : 'lines'}
+        {filtering ? ` of ${history.length.toLocaleString()}` : ''}
+      </Typography>
+
+      <Box
+        data-testid="chat-list"
+        sx={{
+          flex: 1,
+          minHeight: 0,
+          overflowY: 'auto',
+          fontFamily: 'monospace',
+          fontSize: 13,
+          lineHeight: 1.6,
+          border: 1,
+          borderColor: 'divider',
+          borderRadius: 1,
+          px: 1.5,
+          py: 1
+        }}
+      >
+        {rows.length === 0 ? (
+          <NoChat filtered={filtering} />
+        ) : (
+          rows.map((l, i) => (
+            <Box key={i} sx={{ display: 'flex', gap: 1, whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>
+              <Box component="span" sx={{ color: 'text.disabled', flexShrink: 0 }}>
+                {fmtTime(l.ts)}
+              </Box>
+              <Box component="span" sx={{ color: CHANNEL_META[l.channel].color, flexShrink: 0, fontWeight: 600 }}>
+                {speaker(l)}
+              </Box>
+              <Box component="span">{l.text}</Box>
+            </Box>
+          ))
+        )}
+      </Box>
+    </Box>
+  )
+}

--- a/src/renderer/src/features/chat/useChatHistory.ts
+++ b/src/renderer/src/features/chat/useChatHistory.ts
@@ -1,0 +1,15 @@
+// useChatHistory — the chat module's append-only snapshot, as one hook. The loot precedent
+// (useLootHistory.ts): a delta carries `appended`, the snapshot is a concat, forever.
+
+import type { ChatDelta, ChatLine, ChatSnap } from '@shared/types'
+import { useModule } from '../../lib/useModule'
+
+const applyChatDelta = (s: ChatSnap, d: ChatDelta): ChatSnap => [...s, ...d.appended]
+
+/** Stable empty array: a new `[]` each render would re-run every `useMemo` keyed on the history. */
+const NO_CHAT: ChatLine[] = []
+
+/** Every chat line this character has, oldest first. Empty until the snapshot lands. */
+export function useChatHistory(): ChatLine[] {
+  return useModule<ChatSnap, ChatDelta>('chat', applyChatDelta) ?? NO_CHAT
+}

--- a/src/renderer/src/features/preferences/ChatCaptureSetting.tsx
+++ b/src/renderer/src/features/preferences/ChatCaptureSetting.tsx
@@ -1,0 +1,80 @@
+// ChatCaptureSetting — Preferences → Chat → "Save chat to a file" (chat capture).
+//
+// ONE SWITCH, AND IT SHIPS ON. The Chat tab exists to keep your chat; this decides whether it also
+// keeps it BEYOND the game's log — a file the companion appends to as chat arrives, so a rotated or
+// deleted EQ log does not take the history with it. Off, the tab still works (it is rebuilt from
+// the log every launch); only the durable copy stops.
+//
+// STATE, NEVER PROCESS (the repo's UI law): the caption says what the switch DOES and where the
+// file is, not that main holds an append stream or reads the switch per line.
+//
+// NO push listener, unlike CloseToTraySetting: this preference has exactly one control — this card
+// — so it seeds from the pane's snapshot (JOS-340: a control never paints a value it does not
+// know) and follows only its own writes. ONE BORDER: PreferencesView wraps each item in a Paper,
+// so this renders bare Stacks.
+
+import { type JSX, useCallback, useState } from 'react'
+import { FormControlLabel, Stack, Switch, Typography } from '@mui/material'
+import ChatIcon from '@mui/icons-material/Chat'
+import { recordPref, usePrefsSeed } from './prefsHydration'
+import type { PrefSection } from './PreferencesView'
+
+function useChatCapture(): [boolean, (enabled: boolean) => void] {
+  const [enabled, setEnabled] = useState<boolean>(usePrefsSeed().chatCapture)
+
+  const update = useCallback((next: boolean) => {
+    setEnabled(next)
+    recordPref('chatCapture', next)
+    void window.eq.setChatCapture(next).then((stored) => {
+      setEnabled(stored)
+      recordPref('chatCapture', stored)
+    })
+  }, [])
+
+  return [enabled, update]
+}
+
+export function ChatCaptureSetting(): JSX.Element {
+  const [enabled, update] = useChatCapture()
+  return (
+    <Stack spacing={0.5} data-testid="pref-chat-capture">
+      <FormControlLabel
+        control={
+          <Switch
+            size="small"
+            data-testid="pref-save-chat"
+            checked={enabled}
+            onChange={(e) => update(e.target.checked)}
+          />
+        }
+        label={<Typography variant="body2">Also save chat to a file</Typography>}
+      />
+      <Typography variant="caption" color="text.secondary">
+        {enabled
+          ? "New chat is appended to a file in the companion's data folder as it arrives, so it survives the game rotating its log. The Chat tab works either way, and nothing chat-related ever leaves this machine."
+          : 'The Chat tab still shows chat from your current log, but nothing is written to a separate file.'}
+      </Typography>
+    </Stack>
+  )
+}
+
+/**
+ * The section this card is the whole of. A section of its own rather than a line under Overlays or
+ * Window, because it is about the Chat TAB — its own destination in the nav. Descriptor beside the
+ * card for the `windowSection` reason: buildSections is at the 100-code-line ceiling.
+ */
+export function chatSection(): PrefSection {
+  return {
+    id: 'chat',
+    label: 'Chat',
+    icon: <ChatIcon fontSize="small" />,
+    items: [
+      {
+        id: 'chat-capture',
+        label: 'Save chat to a file',
+        keywords: 'chat save log tells guild group channel ooc auction archive file capture messages',
+        content: <ChatCaptureSetting />
+      }
+    ]
+  }
+}

--- a/src/renderer/src/features/preferences/PreferencesView.tsx
+++ b/src/renderer/src/features/preferences/PreferencesView.tsx
@@ -127,6 +127,8 @@ import { appearanceSection } from './TextSizeSetting'
 // Same arrangement again (JOS-139): what the X does — the app keeps running in the tray, or it
 // quits — names its own section beside the card that renders it. See ./CloseToTraySetting.tsx.
 import { windowSection } from './CloseToTraySetting'
+// The Chat tab's save-to-file switch (chat capture) — names its own section beside the card.
+import { chatSection } from './ChatCaptureSetting'
 // Same arrangement again (JOS-73): the release-notes panel names its own section beside the card
 // that renders it. See features/whatsnew/WhatsNewPanel.tsx for why the notes are a SECTION.
 import { whatsNewSection } from '../whatsnew/WhatsNewPanel'
@@ -326,6 +328,8 @@ function buildSections({ version, status, onSendFeedback, onWhatsNew }: SectionI
     // Right after the overlays, because the promise this switch makes is about them: closing the
     // window keeps them running (JOS-139).
     windowSection(),
+    // The Chat tab's one preference: does it also save chat to a file (chat capture).
+    chatSection(),
     graphicsSection(),
     buffTrustSection(),
     cursorRingSection(),

--- a/src/renderer/src/features/preferences/prefsSnapshot.ts
+++ b/src/renderer/src/features/preferences/prefsSnapshot.ts
@@ -136,6 +136,9 @@ export interface PrefsSnapshot {
    *  TWO other controls (the tray menu's checkbox and the title bar's overlay-menu row), so this
    *  entry is kept current by main's pushes as well as by the card's own writes — see App.tsx. */
   closeToTray: CloseToTrayPrefs
+  /** Chat — whether the Chat tab also SAVES live chat to a file (chat capture). ON by default; its
+   *  card is the only control, so unlike closeToTray it needs no push from main. */
+  chatCapture: boolean
   /** Overlays — the celebration toast's open-state and its lock. */
   toast: ToastSeed
   /** Overlays — the alert banner's open-state, lock and knobs. It ships OFF, which is exactly the
@@ -192,6 +195,7 @@ export interface PrefsReader {
   getOverlayBgAlpha: () => Promise<OverlayBgAlphaPrefs>
   getOverlayBgAlphas: () => Promise<Record<OverlayKind, number>>
   getCloseToTray: () => Promise<CloseToTrayPrefs>
+  getChatCapture: () => Promise<boolean>
   getOverlayState: () => Promise<Record<OverlayKind, boolean>>
   getToastConfig: () => Promise<OverlayConfig>
   getAlertBannerConfig: () => Promise<OverlayConfig>
@@ -230,6 +234,7 @@ export async function readPrefsSnapshot(eq: PrefsReader): Promise<PrefsSnapshot>
     overlayBgAlpha,
     overlayBgAlphas,
     closeToTray,
+    chatCapture,
     overlayState,
     toastConfig,
     bannerConfig,
@@ -257,6 +262,7 @@ export async function readPrefsSnapshot(eq: PrefsReader): Promise<PrefsSnapshot>
     eq.getOverlayBgAlpha(),
     eq.getOverlayBgAlphas(),
     eq.getCloseToTray(),
+    eq.getChatCapture(),
     eq.getOverlayState(),
     eq.getToastConfig(),
     eq.getAlertBannerConfig(),
@@ -291,6 +297,7 @@ export async function readPrefsSnapshot(eq: PrefsReader): Promise<PrefsSnapshot>
     overlayBgAlphas,
     overlayOpen: overlayState,
     closeToTray,
+    chatCapture,
     toast: { open: overlayState.toast, locked: toastConfig.locked },
     // The knobs go through the same normalizer main's store reads with, so the cache can never
     // hold an out-of-range hold or line count (the `uiScale` argument, on a different blob).

--- a/src/shared/chatLine.ts
+++ b/src/shared/chatLine.ts
@@ -1,0 +1,91 @@
+// The chat event's SHAPE and its module ROW, in one place both the parser and the renderer import.
+// It is out here rather than in logEvents.ts (the event) / types.ts (the module transport) because
+// BOTH of those files are at their 400-code-line ceiling — the `kills.ts` / `classUnlocks.ts`
+// precedent. logEvents.ts re-exports `ChatChannel` + `ChatEvent`, types.ts re-exports `ChatLine` /
+// `ChatSnap` / `ChatDelta`, so every existing import site reads each name from the file it always
+// did.
+//
+// PRIVACY — the load-bearing invariant. `ChatEvent.text` / `ChatLine.text` is a person's words, so
+// it must never reach a path that leaves the machine. It doesn't: the bus's only off-machine tap is
+// `noteEventKind(ev.kind, ev.ts)` (telemetry breadcrumbs — the STRING 'chat' and a timestamp, no
+// payload, and the error-report path even drops the uncurated 'chat' kind), and the feedback slice
+// + public fixtures work on RAW log lines through `scrubLines()`, which drops every one of these
+// shapes. A ChatEvent is consumed by exactly two LOCAL sinks — the `chat` module (the in-app
+// viewer) and `chatArchive.ts` (the on-disk save) — and a ChatLine crosses the main↔web boundary
+// only over `module:delta` to the user's own window. Neither serializes anywhere but userData. Do
+// NOT add a consumer that forwards `text` off the machine.
+
+import type { LogEventBase } from './logEvents'
+
+/**
+ * A player CHAT line's channel. All player-only, because that is the whole trick: 'tell' (private,
+ * either direction), 'group' (/g + /p), 'guild' (/gu), 'raid' (/rs — unverified in the reference
+ * log, standard EQ wording, synthetic-tested), 'ooc', 'auction', 'shout' (also unverified /
+ * synthetic-tested), 'say', and 'channel' (a custom channel with a slot, e.g. General:1).
+ *
+ * 'say' IS FIRST-PERSON ONLY. A whole-log sweep of eqlog_Jibblits_rivervale (176,296 lines) found
+ * 65 third-party `<Name> says, '…'` lines against ~300 mob-speech `says` lines of the SAME shape
+ * (`A rock golem says`), and single-proper-name NPCs (`Setikan says`) are indistinguishable from
+ * players by shape alone — so third-party say is DROPPED and only `You say, '…'` (unambiguously the
+ * tailed character) is captured. This is the line `shared/logScrub.ts` draws too, from the other
+ * side. See src/main/log/parseChat.ts for the measured per-channel counts and the pet carve-out.
+ */
+export type ChatChannel = 'tell' | 'group' | 'guild' | 'raid' | 'ooc' | 'auction' | 'shout' | 'say' | 'channel'
+
+/**
+ * The ONE event whose payload is a person's WORDS — every other kind reads structure and throws the
+ * words away. It exists so the app can do the two things logScrub was built to stop chat doing to a
+ * PUBLIC artifact, but here on the LOCAL machine where the log already sits: SHOW it live and SAVE
+ * it to a file that survives the game rotating its log.
+ *
+ * IT IS NOT PRODUCED BY THE SINGLE-EVENT PARSE CASCADE, and could not be: `<Name> tells the group,
+ * '…'` is ALREADY a `group` event (parseGroup.ts consumes it as the roster's recovery signal), and
+ * the cascade returns one event per line. Chat is cross-cutting, so it is matched by its own pass
+ * (parseChat.ts) and emitted onto the same bus as an ADDITIONAL event claiming its own seq. Every
+ * existing consumer switches on `ev.kind` and returns for kinds it does not know, so this is inert
+ * to all of them.
+ */
+export interface ChatEvent extends LogEventBase {
+  kind: 'chat'
+  channel: ChatChannel
+  /** The speaker, spelled as the log spelled it (world-model law 2). `'You'` when `self`. */
+  from: string
+  /** True when the tailed character SENT the line (`You tell …` / `You told …` / `You say …`). */
+  self: boolean
+  /** For a private tell the tailed character SENT: who they told. Undefined otherwise. */
+  to?: string
+  /** For `channel`: the channel's name-and-slot exactly as printed, e.g. `'General:1'`. */
+  chan?: string
+  /** The message. A person's WORDS — LOCAL-ONLY (see the header). */
+  text: string
+}
+
+/**
+ * One captured chat line, as the viewer and the on-disk archive both read it: a `ChatEvent` with
+ * the two fields the viewer does not need dropped — `seq` (useModule tracks it on the delta
+ * envelope) and `raw` (the whole log line; the viewer renders the parsed fields). Same append-only
+ * shape as loot: a delta carries `appended`, a snapshot is the concatenation.
+ */
+export interface ChatLine {
+  /** Epoch millis from the bracketed timestamp. */
+  ts: number
+  channel: ChatChannel
+  /** The speaker as the log spelled it; `'You'` when `self`. */
+  from: string
+  /** True when the tailed character sent it. */
+  self: boolean
+  /** Private-tell target, when the tailed character sent the tell. */
+  to?: string
+  /** The custom channel's name-and-slot, e.g. `'General:1'`, for `channel:'channel'`. */
+  chan?: string
+  /** The message. LOCAL-ONLY. */
+  text: string
+}
+
+/** Full history, oldest first. */
+export type ChatSnap = ChatLine[]
+
+/** Everything since the last flush; the renderer concats onto the snapshot. */
+export interface ChatDelta {
+  appended: ChatLine[]
+}

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -327,6 +327,10 @@ export const IPC = {
   // the tray menu's checkbox, or the popover's `Always quit instead`. Payload CloseToTrayPrefs.
   // Without it the Preferences switch and the tray checkbox would be two answers to one question.
   onCloseToTray: 'closeToTray:changed',
+  // ---- the chat viewer also saves to a file (chat capture; storeChatCapture.ts) ----
+  // renderer(main app) -> main: read / set the "save live chat to a file" switch. A plain boolean.
+  chatCaptureGet: 'chatCapture:get',
+  chatCaptureSet: 'chatCapture:set',
   // ---- the tray popover (JOS-139) ----
   // renderer(tray notice window ONLY) -> main. Three SENDS and no reads: the card states what
   // just happened and offers the three ways out of it, and every one of them is a decision main

--- a/src/shared/logEvents.ts
+++ b/src/shared/logEvents.ts
@@ -24,6 +24,11 @@ import type { CoinEvent, ItemReceivedEvent, PurchaseEvent } from './acquireEvent
 // ./gemEvents for the same file-mass reason as the two imports above. Re-exported verbatim.
 import type { SpellForgetEvent, SpellMemorizeEvent, SpellSetEvent } from './gemEvents'
 
+// The CHAT event shape, out in ./chatLine for the same file-mass reason (it sits beside the
+// module row it maps to). Imported here for the union member below; re-exported down beside its
+// doc so every consumer still reads it from `@shared/logEvents`.
+import type { ChatEvent } from './chatLine'
+
 export type { SpellForgetEvent, SpellMemorizeEvent, SpellSetEvent } from './gemEvents'
 
 export type { ConsiderFaction }
@@ -638,6 +643,13 @@ export interface PetSayEvent extends LogEventBase {
   name: string
   say: PetSayKind
 }
+
+// A player CHAT line — the ONE event that carries a person's words. Its shape (ChatEvent) and its
+// channel taxonomy (ChatChannel) live in ./chatLine.ts, beside the module row (ChatLine) they map
+// to and the whole privacy argument, because this file is at its 400-code-line ceiling — the
+// `kills.ts` / `classUnlocks.ts` precedent. Re-exported here so every consumer still imports both
+// from logEvents, exactly as it does the module's own kinds.
+export type { ChatChannel, ChatEvent } from './chatLine'
 
 /**
  * `You begin casting <Spell>.` (and `You begin singing <Song>.` for bard songs) —
@@ -1460,6 +1472,10 @@ export type LogEvent =
   // bind `petClaim` to YOU and none of them should have to learn a new field to keep doing it.
   | AllyPetLeaderEvent
   | PetSayEvent
+  // The ONE event that carries a person's words. Emitted by its own pass beside the cascade
+  // (parseChat.ts), never by `classify()` — see the ChatEvent header. Local-only: two sinks, the
+  // in-app viewer and the on-disk save, and nothing that leaves the machine.
+  | ChatEvent
   | CastBeginEvent
   | OtherCastBeginEvent
   | CastFizzleEvent

--- a/src/shared/telemetry.ts
+++ b/src/shared/telemetry.ts
@@ -122,6 +122,12 @@ export const TELEMETRY_VIEWS = [
   // hard, so releasing the view without adding it here is a red build. Graduation is both halves at
   // once, which is exactly what JOS-327 did.
   'character',
+  // The Chat tab (chat capture). SAME CLOSED-ENUM DEPLOY ORDER as every member added since
+  // JOS-119: the ingest Lambda validates through this module, so the server has to learn 'chat'
+  // BEFORE a client that can emit it ships, or one dwell on this tab 400s the whole batch and drops
+  // every counter in it. It is a REACHABLE tab from day one (unlike the UNRELEASED-gated views), so
+  // it belongs here rather than held back — the dwell histogram wants to know how used it is.
+  'chat',
   'preferences',
   'triage'
 ] as const

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -709,6 +709,11 @@ export interface LootDelta {
   appended: LootEvent[]
 }
 
+// chat module — the append-only chat history. Defined in ./chatLine beside the row shape and the
+// argument for it, on the `kills.ts` precedent (this file is at its line budget). Delta =
+// `ChatLine[]` appended since the last flush; the renderer concats, exactly like loot.
+export type { ChatChannel, ChatLine, ChatSnap, ChatDelta } from './chatLine'
+
 /** turnins module. Delta = turn-ins appended since the last flush. */
 export type TurnInSnap = TurnInEvent[]
 export interface TurnInDelta {

--- a/tests/chatShapes.test.mts
+++ b/tests/chatShapes.test.mts
@@ -1,0 +1,152 @@
+// CHAT PARSING — the player-chat pass beside the cascade (src/main/log/parseChat.ts).
+//
+// THE FIXTURES ARE SYNTHETIC, and that is a privacy requirement, not a shortcut. Every other
+// parse test replays hand-cut windows of the real log; a chat fixture cannot, because a committed
+// fixture goes to a PUBLIC repo and `shared/logScrub.ts` exists precisely to keep a person's words
+// out of one. So the lines below are invented — real SHAPES, fake words and names — which is also
+// why raid/shout (absent from the reference log) can be pinned here at all.
+//
+// The one test that touches the real log is guarded on it existing (CI has no game log) and
+// asserts FLOORS, never today's counts — the log grows by append. It is the guard that proves the
+// two things the header of parseChat.ts promises: enough real player chat is caught, and NO mob
+// `says` line is ever caught as a person's chat.
+
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { existsSync, readFileSync } from 'node:fs'
+import { parseChat } from '../src/main/log/parseChat'
+import type { ChatChannel, ChatEvent } from '../src/shared/logEvents'
+
+/** A plausible EQ Legends timestamp — the shape parseLine strips. The exact instant is irrelevant. */
+const STAMP = '[Wed Aug 13 21:00:00 2025]'
+const line = (body: string): string => `${STAMP} ${body}`
+
+/** parseChat with a throwaway seq — the tests care about the payload, not the number. */
+const chat = (body: string): ChatEvent | null => parseChat(line(body), 1)
+
+test('inbound channels name the speaker and carry the message', () => {
+  const cases: [string, Partial<ChatEvent> & { channel: ChatChannel }][] = [
+    ["Frikniller tells you, 'hey there'", { channel: 'tell', from: 'Frikniller', self: false, text: 'hey there' }],
+    ["Grimtooth tells the guild, 'inc named'", { channel: 'guild', from: 'Grimtooth', self: false, text: 'inc named' }],
+    ["Bortho tells the group, 'pull left'", { channel: 'group', from: 'Bortho', self: false, text: 'pull left' }],
+    ["Ander says out of character, 'lol'", { channel: 'ooc', from: 'Ander', self: false, text: 'lol' }],
+    ["Cidwin auctions, 'wts fine steel'", { channel: 'auction', from: 'Cidwin', self: false, text: 'wts fine steel' }],
+    // UNVERIFIED shapes (absent from the reference log) — pinned from EQ's own wording.
+    ["Xandor tells the raid, 'assist me'", { channel: 'raid', from: 'Xandor', self: false, text: 'assist me' }],
+    ["Xandor shouts, 'zone is up'", { channel: 'shout', from: 'Xandor', self: false, text: 'zone is up' }]
+  ]
+  for (const [body, want] of cases) {
+    const ev = chat(body)
+    assert.ok(ev, `expected chat for: ${body}`)
+    for (const [k, v] of Object.entries(want)) assert.equal((ev as never)[k], v, `${body} → ${k}`)
+    assert.equal(ev.to, undefined)
+    assert.equal(ev.chan, undefined)
+  }
+})
+
+test('custom channels capture the name-and-slot in chan', () => {
+  for (const name of ['General:1', 'General1:1']) {
+    const ev = chat(`Zeek tells ${name}, 'wtb spell'`)
+    assert.ok(ev)
+    assert.equal(ev.channel, 'channel')
+    assert.equal(ev.from, 'Zeek')
+    assert.equal(ev.self, false)
+    assert.equal(ev.chan, name)
+    assert.equal(ev.text, 'wtb spell')
+  }
+})
+
+test('outbound lines are first-person and carry the tell target', () => {
+  const tell = chat("You told Frikniller, 'hi back'")
+  assert.deepEqual(
+    tell && { c: tell.channel, self: tell.self, to: tell.to, text: tell.text },
+    { c: 'tell', self: true, to: 'Frikniller', text: 'hi back' }
+  )
+  // A tell target is printed however it was typed — lowercase included.
+  assert.equal(chat("You told ahrima, 'yo'")?.to, 'ahrima')
+
+  const outbound: [string, ChatChannel][] = [
+    ["You say to your guild, 'omw'", 'guild'],
+    ["You tell your party, 'oom'", 'group'],
+    ["You tell General:1, 'anyone selling?'", 'channel'],
+    ["You say out of character, 'gg'", 'ooc'],
+    ["You auction, 'wts loot'", 'auction'],
+    ["You tell your raid, 'incoming'", 'raid'],
+    ["You shout, 'help in zone'", 'shout'],
+    ["You say, 'hello zone'", 'say']
+  ]
+  for (const [body, channel] of outbound) {
+    const ev = chat(body)
+    assert.ok(ev, `expected chat for: ${body}`)
+    assert.equal(ev.channel, channel, body)
+    assert.equal(ev.self, true, body)
+    assert.equal(ev.from, 'You', body)
+  }
+})
+
+test('an apostrophe inside the message is kept (greedy to the true closing quote)', () => {
+  assert.equal(chat("Ander says out of character, 'don't go'")?.text, "don't go")
+  assert.equal(chat("You say, 'that's mine'")?.text, "that's mine")
+})
+
+test('an empty message parses to empty text, not to null', () => {
+  const ev = chat("Bortho tells the group, ''")
+  assert.ok(ev)
+  assert.equal(ev.text, '')
+})
+
+test('a group tell is chat even though the cascade also reads it as a roster signal', () => {
+  // The whole reason chat rides its own pass: parseGroup consumes this same line as `group`. Here
+  // it must ALSO yield a chat event — that is what makes group chat saveable.
+  const ev = chat("Bortho tells the group, 'oom, need a sec'")
+  assert.equal(ev?.channel, 'group')
+  assert.equal(ev?.text, 'oom, need a sec')
+})
+
+test('non-player speech and non-chat lines are refused', () => {
+  const refused = [
+    "A rock golem says, 'Die, intruder!'", // mob say (multi-word name)
+    "Setikan says, 'greetings'", // third-party /say — mob-ambiguous, deliberately dropped
+    "Bortho says, 'anyone home'", // ditto, even a clean single-word name
+    "Vebarn told you, 'Attacking a rat Master.'", // pet-claim tell (told you, not tells you)
+    "Jaber says, 'My leader is Primitive.'", // pet-leader say (a third-party says)
+    'You have entered the Plane of Sky.', // no quoted speech at all
+    'Frikniller hits a rat for 12 points of damage.' // combat, not chat
+  ]
+  for (const body of refused) assert.equal(chat(body), null, `should refuse: ${body}`)
+})
+
+// ---------------------------------------------------------------------------
+// The real-log guard. Only runs where the reference log exists (never CI). Floors, not counts.
+// ---------------------------------------------------------------------------
+const REF_LOG =
+  'C:/Users/Public/Daybreak Game Company/Installed Games/EverQuest Legends/Logs/eqlog_Jibblits_rivervale.txt'
+
+test('over the real log: enough player chat, and no mob speech, is captured', { skip: !existsSync(REF_LOG) }, () => {
+  // Split on CRLF too: the feeders hand parseChat a `\r`-stripped line (see LogEventBase.raw), so
+  // the test must strip it as well, or the `'$` anchor never sees the closing quote as last.
+  const lines = readFileSync(REF_LOG, 'utf8').split(/\r?\n/)
+  const byChannel = new Map<ChatChannel, number>()
+  let seq = 0
+  for (const raw of lines) {
+    const ev = parseChat(raw, seq++)
+    if (!ev) continue
+    byChannel.set(ev.channel, (byChannel.get(ev.channel) ?? 0) + 1)
+    // NO third-party `say` is ever captured (the mob-ambiguity rule): every `say` is the player's.
+    if (ev.channel === 'say') assert.equal(ev.self, true, `third-party say leaked: ${ev.raw}`)
+    // NO captured speaker is a multi-word mob name (`a rock golem`): a player's name is one token.
+    if (!ev.self) assert.ok(!/\s/.test(ev.from), `multi-word speaker leaked: ${ev.raw}`)
+  }
+  // Floors from the measured sweep (channel 5924, guild 338, group 146, tell 55, say 31); halved-ish
+  // so an appended log only ever pushes them up.
+  const floor: [ChatChannel, number][] = [
+    ['channel', 5000],
+    ['guild', 250],
+    ['group', 120],
+    ['tell', 40],
+    ['say', 20]
+  ]
+  for (const [c, n] of floor) {
+    assert.ok((byChannel.get(c) ?? 0) >= n, `channel ${c}: ${byChannel.get(c) ?? 0} < floor ${n}`)
+  }
+})

--- a/tests/prefsHydration.test.mts
+++ b/tests/prefsHydration.test.mts
@@ -80,6 +80,8 @@ function stubReader(over: Partial<Record<keyof PrefsReader, unknown>> = {}): {
     // reversal) — and the one with TWO other controls (the tray menu's checkbox and the title bar's
     // overlay-menu row) that can move it while this pane is closed.
     getCloseToTray: answer('getCloseToTray', { enabled: true, noticeAcknowledged: true }),
+    // The chat-capture switch (chat capture) — default ON, one control, no push.
+    getChatCapture: answer('getChatCapture', true),
     // The open-state map. THREE fields of it become the toast / banner / con-card cards' seeds, and
     // since JOS-408 the WHOLE map is also kept, for the Overlays rows' `closed` tag — one read,
     // four readers, which is the point of a batch.
@@ -117,11 +119,11 @@ test('one read answers every card in the pane, and it snaps the text size to the
   const { reader, calls } = stubReader()
   const snap = await readPrefsSnapshot(reader)
 
-  // TWENTY-SIX reads, one batch (JOS-405 added the overlays' text size and its twelve per-kind
-  // values; JOS-407 the same pair for transparency). The number is not the claim; the claim is
-  // that the gate asks each question exactly once, so a pane that mounts does not stampede the
-  // store.
-  assert.equal(calls(), 26, 'every read fires exactly once')
+  // TWENTY-SEVEN reads, one batch (JOS-405 added the overlays' text size and its twelve per-kind
+  // values; JOS-407 the same pair for transparency; chat capture added the save-to-file switch).
+  // The number is not the claim; the claim is that the gate asks each question exactly once, so a
+  // pane that mounts does not stampede the store.
+  assert.equal(calls(), 27, 'every read fires exactly once')
 
   // The overlays' size (JOS-405), which is TWO facts read together for the toast pair's reason:
   // the shared stepper and the twelve rows are one control group, and a frame where the size was
@@ -200,7 +202,7 @@ test('two mounts in one frame share ONE batch', async () => {
   resetPrefsSnapshotForTests()
   const { reader, calls } = stubReader()
   const [a, b] = await Promise.all([loadPrefsSnapshot(reader), loadPrefsSnapshot(reader)])
-  assert.equal(calls(), 26, 'not fifty-two')
+  assert.equal(calls(), 27, 'not fifty-four')
   assert.equal(a, b)
   resetPrefsSnapshotForTests()
 })


### PR DESCRIPTION
## What

A **Chat** tab that shows every player chat line the log holds — tells, guild, group, custom channels (e.g. `General:1`), OOC, auction, and your own `/say` — with per-channel filters and search. Optionally (on by default, toggle in **Preferences → Chat**) it also **saves** chat to a per-character file so the history survives the game rotating its log.

Requested by a user who wanted to save all chat messages from their log.

## Design

- **New `chat` `LogEvent`, matched by its own pass** (`src/main/log/parseChat.ts`), *beside* the single-event cascade rather than inside it. A `<Name> tells the group, '…'` line is already a `group` roster event, and the cascade returns exactly one event per line — so chat, which is cross-cutting, is emitted as an **additional** bus event claiming its own seq. Every existing consumer switches on `ev.kind` and no-ops on the new kind. The shape lives in `src/shared/chatLine.ts` (both `logEvents.ts` and `types.ts` are at their 400-line ceiling — the `kills.ts` precedent) and is re-exported from both.
- **Viewer:** a `chat` module (mirrors `loot`) folded into an append-only history the tab hydrates from and rides deltas on, over the existing `module:delta` transport — **no new renderer IPC**.
- **Save:** `src/main/chatArchive.ts`, a *live-only* bus sink appending JSONL to `<userData>/chat/<name_server>.jsonl`. Replayed history is ignored (it's already in the game's log), so the archive accumulates **forward** and never duplicates on relaunch. Gated by a boolean store pref (`storeChatCapture.ts`, additive/optional, no schema bump — the `closeToTray` carve-out).

## Which channels — and why third-party `/say` is left out

Every directed/social channel whose speaker is **unambiguously a player**. Third-party `<Name> says, '…'` is dropped on purpose: a whole-log sweep (176,296 lines) showed it's the *same shape* as mob speech (`A rock golem says`) and single-name NPCs (`Setikan says`), indistinguishable by shape alone — so `say` is captured only in its first-person form (`You say`). This is exactly the line `shared/logScrub.ts` already draws, from the other side. `raid`/`shout` didn't occur in the reference log; they're written from EQ's standard wording and marked UNVERIFIED, tested from synthetic lines.

## Privacy — deliberately consistent with this repo's stance

The codebase is explicit that chat content must never leave the machine (`logScrub.ts` drops all quoted speech from public fixtures and feedback slices; "nothing in this app parses chat"). This feature keeps that invariant:

- Chat `text` is consumed by exactly **two local sinks** — the in-app viewer and the on-disk file — both writing only to the user's own `userData`.
- The bus's only off-machine tap records the **kind string + timestamp** (no payload); the error-report path even **drops** the uncurated `'chat'` breadcrumb kind (same as `ccWake`).
- The feedback slice and public fixtures still scrub raw log lines through `scrubLines()`, which drops every one of these shapes.

**A judgment call for you:** the durable file defaults **ON** (it's the point of the feature, and the same words already sit uncensored in the game's own log on the same disk). If you'd rather it defaulted OFF, it's a one-line flip in `storeChatCapture.ts` (`?? true` → `?? false`) — everything else is unchanged.

## Note for you: telemetry view enum

`'chat'` was added to `TELEMETRY_VIEWS` (the active-tab dimension). Per the repeated deploy-order comments there, the ingest Lambda validates this closed enum, so **the server needs to learn `'chat'` before a client that can emit it ships**, or a dwell on the tab 400s the batch. `TELEMETRY.md` was regenerated via `npm run gen:telemetry-doc`.

## Verification

- `tsc` node + web: clean
- `eslint` (with the ratchet): **0 issues**
- Full suite: **5074 pass / 0 fail**, including a new `tests/chatShapes.test.mts` that pins every channel on synthetic lines, keeps chat fixtures synthetic (no real words in a public repo), and floor-checks the real log with **zero mob speech captured**
- `electron-vite build`: succeeds

I could not run the packaged app in this environment, so the switches were verified by typecheck + unit tests, not by clicking them. Happy to adjust naming, placement, defaults, or the `/say` decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
