### PR TITLE
Debuffs: Curse's landing regains its subject, so the level-34 curse reaches the window (fixes #43)

### DIFF
--- a/src/main/data/spellCorrectionsSubjects.ts
+++ b/src/main/data/spellCorrectionsSubjects.ts
@@ -427,6 +427,14 @@ const SUBJECT_DRIFTS: readonly SubjectDrift[] = [
     attribution: 'cast',
     evidence:
       'THE REPORTED DEFECT (01KZSR4HQVWJKDG0NCDGZ01928, v0.21.0, a druid): Vengeance of the Wild does not appear in debuff tracking. THE OWNER`S LOG CANNOT WITNESS IT — 1,608,490 lines measured 2026-08-12 hold 0 of the restored shape, 0 of the wiki form, 0 of the self landing, 0 of the wear-off and not one line naming the spell at all — so the evidence log is the reporter`s slice, cited by id (see THE ROW THE OWNER`S LOG CANNOT WITNESS in this file`s header). That slice, 3,405 lines through the real parser: 7 `You begin casting Vengeance of the Wild VI.` casts, 6 lines of `<mob> has been consumed in the flames of the wild.`, one per cast at EXACTLY +2 s, and the 7th cast is the one it shows interrupted. 0 of the wiki form. The tail is new to the suffix table and no other DB message mentions the flames of the wild, so nothing else could be meant either.'
+  },
+  {
+    spells: ['Curse'],
+    from: 'Target has been cursed.',
+    to: 'Someone has been cursed.',
+    hits: 0,
+    evidence:
+      'THE REPORTED DEFECT (GitHub issue #43, a shaman): "the shaman spell Curse level 34 isnt showing on the debuff tracker overlay". The Odium defect exactly, one rank down the same shaman curse line — that row (above) proved the drift for this line`s 43. THE REPORT CARRIES NO LOG, so there is no slice to count and `hits: 0` here means UNMEASURED BY THE CONTRIBUTOR, not witnessed-absent: this row was authored outside the owner`s tree and the owner-log pass (count of `<T> has been cursed.`, wiki form, and the tripwire replay) still needs the owner`s log. What IS measured, against the committed DB: the tail is minted — no other spell writes this sentence; `Magi Curse` owns `has been Magi cursed.`, and neither tail is a suffix of the other (tests/spellCorrectionsSubjects.test.mts pins the pair); `Vexing Mordinia` and `Odium` write different curse sentences — and the entry corroborates itself: `msgCastOnYou` is the exact first-person half, `You have been cursed.` The sentence matches neither emote regex (feels/looks/seems verbs only) and no poison-proc suffix, so nothing is taken from any classifier below.'
   }
 ]
 

--- a/tests/spellCorrectionsSubjects.test.mts
+++ b/tests/spellCorrectionsSubjects.test.mts
@@ -605,3 +605,47 @@ test('JOS-103`s type-less line has a typed event now: Spirit of the Puma', () =>
   assert.equal(ev?.kind, 'buffApply')
   assert.equal(ev.kind === 'buffApply' ? ev.spell : '', 'Spirit of the Puma')
 })
+
+// ---------------------------------------------------------------------------------------------
+// 7 — THE SIXTH REPORT: Curse, the level-34 rank of the line Odium already proved (issue #43)
+// ---------------------------------------------------------------------------------------------
+
+test('issue #43: a Curse cast plus the live landing opens a DEBUFF bar', () => {
+  // THE REPORTED DEFECT (github.com/jmoyers/everquest-companion issue #43, a shaman): "the shaman
+  // spell Curse level 34 isnt showing on the debuff tracker overlay". The report carries no log,
+  // so no reporter bytes exist to quote: the cast line is the game's standard shape for the DB's
+  // own spell name, and the landing is the wiki's own sentence with the subject restored — the
+  // same one token this sweep exists to restore. The DB corroborates the sentence from inside the
+  // entry itself: `msgCastOnYou` is its exact first-person half, `You have been cursed.`
+  const r = replay([[0, 'You begin casting Curse.'], [3, 'a rock golem has been cursed.']], 10)
+  const row = r.rows.find((x) => x.target === 'a rock golem')
+  assert.ok(row, `no Curse row: ${r.rows.map((x) => `${x.name}@${x.target ?? 'self'}`).join(', ') || '(none)'}`)
+  assert.equal(row.name, 'Curse')
+  assert.equal(row.kind, 'debuff', 'spellType `Curse` folds detrimental (spellDb.ts DETRIMENTAL_TYPES)')
+  assert.equal(row.mode, 'countdown', 'a bar with a duration, which is the whole report')
+  assert.equal(row.durationMs, 30_000, 'the committed DB states 30 seconds')
+  assert.ok(rowsForSurface(r.rows, 'debuffs').includes(row), 'and it belongs to the DEBUFFS window')
+  assert.ok(r.active.some((a) => a.spell === 'Curse' && a.target === 'a rock golem'), 'the held instance under the row')
+})
+
+test('…and WITHOUT the sweep the Curse landing matches nothing at all, which is the defect', () => {
+  // The wiki writes `Target has been cursed.`, subject `Target`, so the spell yields no suffix and
+  // is in no table — the Odium defect exactly, one rank down the same shaman line.
+  const bare = buildSpellDb(applySpellCorrections(RAW, HAND_DERIVED).spells)
+  assert.equal(matchCastOnOtherSuffix('a rock golem has been cursed.', bare), null)
+  assert.equal(castOnOtherSuffix(bare.byKey.get('curse')?.msgCastOnOther ?? ''), null)
+})
+
+test('the Curse landing resolves to Curse alone, and Magi Curse keeps its own tail', () => {
+  // The near-neighbour the mint must NOT collide with: `Someone has been Magi cursed.` ends in the
+  // same two words but neither tail is a suffix of the other (` has been cursed.` vs ` has been
+  // Magi cursed.`), so each line has exactly one owner. Invariant 2 pins the general rule; this
+  // pins the one concrete pair a reader would worry about.
+  const db = loadSpellDb()
+  const hit = matchCastOnOtherSuffix('a rock golem has been cursed.', db)
+  assert.ok(hit, 'the live sentence must resolve at all')
+  assert.equal(hit.target, 'a rock golem')
+  assert.deepEqual(hit.entry.cands.map((c) => c.name), ['Curse'], 'no other spell writes this sentence')
+  const magi = matchCastOnOtherSuffix('a rock golem has been Magi cursed.', db)
+  assert.deepEqual(magi?.entry.cands.map((c) => c.name), ['Magi Curse'])
+})


### PR DESCRIPTION
Fixes #43 — "the shaman spell Curse level 34 isnt showing on the debuff tracker overlay".

## The defect

It is the JOS-174 subject-placeholder drift, exactly: the wiki writes Curse's third-person landing as `Target has been cursed.`, `castOnOtherSuffix()` keys the cast-on-other table on what follows a `Someone ` subject and nothing else, so the spell was in no table, `<mob> has been cursed.` classified as `{kind:'unknown'}`, and no `buffApply` ever existed for a bar to draw. Odium — the level-43 rank of the same shaman curse line — was this sweep's founding case; issue #43 is the same defect one rank down, and by the awaiting-sample law it waited for exactly this report.

## The fix

One `SubjectDrift` row in `spellCorrectionsSubjects.ts` (`Target has been cursed.` → `Someone has been cursed.`), plus the acceptance trio in `tests/spellCorrectionsSubjects.test.mts` mirroring Odium's: the cast + landing opens a debuff bar with the DB's 30 s through the real parser and modules; without the sweep the same sentence resolves to nothing; and the landing resolves to Curse alone.

Measured against the committed DB:
- The tail is **minted** — no other spell writes this sentence. `Magi Curse` owns `has been Magi cursed.`; neither tail is a suffix of the other, and a test pins that concrete pair (invariant 2 pins the general rule).
- Nothing is taken from below: the sentence matches neither emote regex (`feels/looks/seems` verbs only) nor any poison-proc suffix. `Vexing Mordinia` and `Odium` write different curse sentences.
- The entry corroborates itself: `msgCastOnYou` is the exact first-person half, `You have been cursed.`, and `spellType: Curse` already folds detrimental (`DETRIMENTAL_TYPES`), so the row routes to the DEBUFFS window.

## What I could not measure, stated rather than papered over

The report carries no log, and the owner's evidence log (`eqlog_Primitive_freeport.txt`) is not in the tree — so this row ships `hits: 0` with evidence text that says plainly it means **unmeasured by the contributor**, not witnessed-absent. The whole-log count of the restored shape and the law-8 tripwire replay (parse twice, diff every kind) still need a pass on the owner's log. Happy to adjust the row's evidence once that number exists; I've also asked the reporter for a log snippet on the issue, which would upgrade the attribution to `cast`.

## Verification

- `npm run typecheck` — pass
- `npm run lint` — pass (the test file sits under the 400-line ceiling)
- `npm test` — 5028/5069; the 4 failures are the same platform-dependent set that fails on clean `main` on macOS (one is #23's subject)
- New tests fail before the row, pass after; the sweep's invariant suite (shape, additive-at-the-table, refusals) stays green

🤖 Generated with [Claude Code](https://claude.com/claude-code)