### PR TITLE
Bosses: hide mobs from Raid Targets - a per-target flag, the toolbar's peek, and an honest denominator (fixes #32)

### DIFF
--- a/src/renderer/src/features/bosses/BossSections.tsx
+++ b/src/renderer/src/features/bosses/BossSections.tsx
@@ -40,7 +40,7 @@
 
 import { type JSX, useMemo, useState } from 'react'
 import { Box, Chip, Paper, Stack, Typography } from '@mui/material'
-import CheckIcon from '@mui/icons-material/Check'
+import { HideTargetButton, TargetKilledBadge } from './cardCorners'
 import type { RaidTarget } from '@shared/types'
 import type { TargetStatus } from './bossStatus'
 import { tierLadder, type LadderRung, type TierLock } from './lockout'
@@ -115,29 +115,6 @@ function BossImage({
 }
 
 // The little tier-coloured tick in the card's top-left corner: "you have this one".
-function TargetKilledBadge({ tier }: { tier: TierStyle }): JSX.Element {
-  return (
-    <Box
-      sx={{
-        position: 'absolute',
-        top: 4,
-        left: 4,
-        zIndex: 1,
-        width: 20,
-        height: 20,
-        borderRadius: '50%',
-        bgcolor: tier.bg,
-        color: tier.fg,
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-        boxShadow: 1
-      }}
-    >
-      <CheckIcon sx={{ fontSize: 14 }} />
-    </Box>
-  )
-}
 
 /**
  * What the corner chip says, and whether the card reads as "you have this one".
@@ -301,7 +278,9 @@ function TargetCard({
   flash,
   lock,
   ladder,
-  onOpen
+  onOpen,
+  hidden = false,
+  onToggleHidden
 }: {
   s: TargetStatus
   compact: boolean
@@ -314,6 +293,10 @@ function TargetCard({
    */
   ladder?: LadderRung[]
   onOpen: () => void
+  /** This target is hidden (issue #32) — the card only renders under the toolbar's peek, DIMMED,
+   *  so a peeked roster reads as two populations rather than quietly merging them back. */
+  hidden?: boolean
+  onToggleHidden?: () => void
 }): JSX.Element {
   const imgH = compact ? 70 : 120
   const chip = chipFacts(s, tierStyle(s.bestTier), lock)
@@ -339,10 +322,12 @@ function TargetCard({
             : 'none',
         transform: flash ? 'scale(1.04)' : 'none',
         transition: 'transform 200ms, box-shadow 200ms, border-color 200ms',
-        '&:hover': { transform: flash ? 'scale(1.04)' : 'translateY(-2px)' }
+        '&:hover': { transform: flash ? 'scale(1.04)' : 'translateY(-2px)' },
+        opacity: hidden ? 0.45 : 1
       }}
     >
       {chip.on && <TargetKilledBadge tier={tier} />}
+      {onToggleHidden && <HideTargetButton name={s.target.name} hidden={hidden} onToggle={onToggleHidden} />}
       <TargetCardMedia s={s} chip={chip} height={imgH} />
       <TargetCardCaption s={s} compact={compact} ladder={ladder} />
     </Paper>
@@ -363,6 +348,10 @@ interface GridProps {
    * record.
    */
   lockOf?: (s: TargetStatus) => TierLock[]
+  /** Is this target hidden (issue #32)? A hidden card renders only under the toolbar's peek. */
+  hiddenOf?: (name: string) => boolean
+  /** The card's own hide/unhide control writes through this — the one writer of the set. */
+  onToggleHidden?: (name: string) => void
 }
 
 /** Everything a section needs to draw its grid — identical for both groupings. */
@@ -384,7 +373,7 @@ function wholeRows(list: TargetStatus[]): CardRow[] {
 }
 
 /** A header plus the grid under it. The ONE grid in this feature; both groupings use it. */
-function Section({ header, rows, compact, minCol, flashing, onOpenMob, lockOf }: GridProps & { header: JSX.Element; rows: CardRow[] }): JSX.Element {
+function Section({ header, rows, compact, minCol, flashing, onOpenMob, lockOf, hiddenOf, onToggleHidden }: GridProps & { header: JSX.Element; rows: CardRow[] }): JSX.Element {
   return (
     <Box sx={{ mb: compact ? 1.5 : 2.5 }}>
       {header}
@@ -410,6 +399,8 @@ function Section({ header, rows, compact, minCol, flashing, onOpenMob, lockOf }:
             // grouping (the default) `whole` IS `s`, so nothing moves there.
             ladder={lockOf && tierLadder(lockOf(row.whole))}
             onOpen={() => onOpenMob(mobTargetForStatus(row.whole))}
+            hidden={hiddenOf?.(row.s.target.name) ?? false}
+            onToggleHidden={onToggleHidden && (() => onToggleHidden(row.s.target.name))}
           />
         ))}
       </Box>

--- a/src/renderer/src/features/bosses/BossView.tsx
+++ b/src/renderer/src/features/bosses/BossView.tsx
@@ -22,9 +22,10 @@ import { getBossData } from '../../data'
 import { useBossKills } from './useBossKills'
 import type { BossKill, TargetStatus } from './bossStatus'
 import { CategorySection, LoadoutSections } from './BossSections'
-import { untilReset } from './lockout'
+import { untilReset, type LockoutWindow, type TierLock } from './lockout'
 import { useLockoutWeek } from './useLockoutWeek'
 import { defeatedThisWeek, everDefeated, filterRoster } from './rosterFilter'
+import { useHiddenRoster } from './useHiddenTargets'
 import type { MobTarget } from '../mobs/mobTarget'
 import Confetti from '../../lib/Confetti'
 
@@ -65,6 +66,25 @@ function loadMode(): Mode {
 
 const bosses = getBossData()
 
+/**
+ * The toolbar's tally line — the denominator every filter is measured against (see the roster
+ * note in BossView), folded outside the component because the view is at the measured
+ * per-function ceiling and this is a pure sentence over inputs the view already owns.
+ */
+function tallyLine(
+  mode: Mode,
+  roster: TargetStatus[],
+  lockOf: (s: TargetStatus) => TierLock[],
+  week: LockoutWindow
+): string {
+  if (mode === 'week') {
+    const locked = roster.filter((s) => lockOf(s).length > 0).length
+    return `${locked} / ${roster.length} locked this week · resets in ${untilReset(week)} · green rung = cleared`
+  }
+  const everKilled = roster.filter((s) => s.killed).length
+  return `${everKilled} / ${roster.length} defeated · badge = highest instance tier`
+}
+
 // Mode / search / defeated-only / grouping / density, plus the running tally on the right.
 function BossToolbar({
   mode,
@@ -80,12 +100,16 @@ function BossToolbar({
   onModeChange: (m: Mode | null) => void
   query: string
   onQueryChange: (q: string) => void
-  /** The two switches, bundled so the toolbar keeps a readable parameter list. */
+  /** The switches, bundled so the toolbar keeps a readable parameter list. */
   filters: {
     defeatedOnly: boolean
     onDefeatedOnlyChange: (v: boolean) => void
     byLoadout: boolean
     onByLoadoutChange: (v: boolean) => void
+    /** How many targets are hidden (issue #32). Zero ⇒ the switch is not drawn at all. */
+    hiddenCount: number
+    showHidden: boolean
+    onShowHiddenChange: (v: boolean) => void
   }
   density: Density
   onDensityChange: (d: Density | null) => void
@@ -138,6 +162,22 @@ function BossToolbar({
         }
         label="By class loadout"
       />
+      {/* THE HIDE FLAG'S PEEK (issue #32): drawn only while something IS hidden, so the toolbar
+          pays nothing until the feature is used, and labelled with the count because the number
+          is the whole reason to flip it — "what am I not seeing". While on, hidden cards render
+          dimmed with their restore control; the set itself moves only on the card's own button. */}
+      {filters.hiddenCount > 0 && (
+        <FormControlLabel
+          control={
+            <Switch
+              data-testid="boss-show-hidden"
+              checked={filters.showHidden}
+              onChange={(e) => filters.onShowHiddenChange(e.target.checked)}
+            />
+          }
+          label={`Hidden (${String(filters.hiddenCount)})`}
+        />
+      )}
       <ToggleButtonGroup
         size="small"
         exclusive
@@ -196,6 +236,9 @@ export default function BossView({ onOpenMob }: { onOpenMob: (t: MobTarget) => v
   }, [])
 
   const { statuses } = useBossKills(bosses.targets, { onKill })
+  // Hidden targets (issue #32): the persisted set, the unpersisted peek, and the visible
+  // roster the tally reads. The bundle's doc (useHiddenTargets.ts) carries the rules.
+  const { hidden, showHidden, setShowHidden, roster } = useHiddenRoster(statuses)
 
   const setDensityPersist = (d: Density | null): void => {
     if (!d) return
@@ -219,8 +262,8 @@ export default function BossView({ onOpenMob }: { onOpenMob: (t: MobTarget) => v
   )
 
   const filtered = useMemo(
-    () => filterRoster(statuses, { query, defeatedOnly, defeated }),
-    [statuses, query, defeatedOnly, defeated]
+    () => filterRoster(statuses, { query, defeatedOnly, defeated, hidden: hidden.keys, showHidden }),
+    [statuses, query, defeatedOnly, defeated, hidden.keys, showHidden]
   )
 
   const byCategory = useMemo(() => {
@@ -235,19 +278,17 @@ export default function BossView({ onOpenMob }: { onOpenMob: (t: MobTarget) => v
     )
   }, [filtered])
 
-  // The tally counts the WHOLE roster, never `filtered` — it is the denominator the filter is
-  // measured against, so it must not move when a switch is flipped.
-  const locked = statuses.filter((s) => lockOf(s).length > 0).length
-  const everKilled = statuses.filter((s) => s.killed).length
-  const tally =
-    mode === 'week'
-      ? `${locked} / ${statuses.length} locked this week · resets in ${untilReset(week)} · green rung = cleared`
-      : `${everKilled} / ${statuses.length} defeated · badge = highest instance tier`
+  // The tally counts the ROSTER, never `filtered` — the denominator the filters are measured
+  // against, so it must not move when a switch is flipped. Since issue #32 the roster is the
+  // VISIBLE one (useHiddenRoster): a hidden target leaves the denominator too.
+  const tally = tallyLine(mode, roster, lockOf, week)
   const section = {
     compact,
     minCol: compact ? 116 : 180,
     flashing,
     onOpenMob,
+    hiddenOf: hidden.has,
+    onToggleHidden: hidden.toggle,
     ...(mode === 'week' ? { lockOf } : {})
   }
 
@@ -269,7 +310,10 @@ export default function BossView({ onOpenMob }: { onOpenMob: (t: MobTarget) => v
           defeatedOnly,
           onDefeatedOnlyChange: setDefeatedOnly,
           byLoadout,
-          onByLoadoutChange: setByLoadout
+          onByLoadoutChange: setByLoadout,
+          hiddenCount: hidden.size,
+          showHidden,
+          onShowHiddenChange: setShowHidden
         }}
         density={density}
         onDensityChange={setDensityPersist}

--- a/src/renderer/src/features/bosses/cardCorners.tsx
+++ b/src/renderer/src/features/bosses/cardCorners.tsx
@@ -1,0 +1,78 @@
+// THE CARD'S TWO CORNER CONTROLS — the kill badge (top-left) and hide/unhide (top-right).
+// Their own file because BossSections is at the measured file ceiling and both are
+// self-contained: one draws a fact, the other writes one flag.
+//
+// HIDE/UNHIDE (GitHub issue #32). Extracted with the badge because BossSections
+// is at the measured file ceiling and this control is a self-contained intent: one button, one
+// writer of the hidden set (useHiddenTargets via the section props), no reading of the roster.
+//
+// It sits top-RIGHT because the kill badge owns top-left. It STOPS the click: the card routes
+// to the mob page, and hiding a card must not also open it. The icon is the state you would
+// MOVE TO (an eye on a hidden card, a struck eye on a visible one), matching the toolbar peek's
+// vocabulary. Low opacity until hover on a visible card so the control does not compete with
+// the art it sits over; near-full on a hidden card, where the control IS the point.
+
+import type { JSX } from 'react'
+import { Box, IconButton } from '@mui/material'
+import CheckIcon from '@mui/icons-material/Check'
+import type { TierStyle } from '../../lib/tierChip'
+import VisibilityOffOutlinedIcon from '@mui/icons-material/VisibilityOffOutlined'
+import VisibilityOutlinedIcon from '@mui/icons-material/VisibilityOutlined'
+
+export function HideTargetButton({
+  name,
+  hidden,
+  onToggle
+}: {
+  name: string
+  hidden: boolean
+  onToggle: () => void
+}): JSX.Element {
+  return (
+    <IconButton
+      data-testid="boss-card-hide"
+      aria-label={hidden ? `unhide ${name}` : `hide ${name}`}
+      size="small"
+      onClick={(e) => {
+        e.stopPropagation()
+        onToggle()
+      }}
+      sx={{
+        position: 'absolute',
+        top: 2,
+        right: 2,
+        zIndex: 1,
+        color: 'text.secondary',
+        bgcolor: 'background.paper',
+        opacity: hidden ? 0.9 : 0.35,
+        '&:hover': { opacity: 1, bgcolor: 'background.paper' }
+      }}
+    >
+      {hidden ? <VisibilityOutlinedIcon fontSize="inherit" /> : <VisibilityOffOutlinedIcon fontSize="inherit" />}
+    </IconButton>
+  )
+}
+
+export function TargetKilledBadge({ tier }: { tier: TierStyle }): JSX.Element {
+  return (
+    <Box
+      sx={{
+        position: 'absolute',
+        top: 4,
+        left: 4,
+        zIndex: 1,
+        width: 20,
+        height: 20,
+        borderRadius: '50%',
+        bgcolor: tier.bg,
+        color: tier.fg,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        boxShadow: 1
+      }}
+    >
+      <CheckIcon sx={{ fontSize: 14 }} />
+    </Box>
+  )
+}

--- a/src/renderer/src/features/bosses/rosterFilter.ts
+++ b/src/renderer/src/features/bosses/rosterFilter.ts
@@ -55,7 +55,7 @@ export function defeatedThisWeek(w: LockoutWindow): DefeatedTest {
   return (s) => tierLocks(s.tiers, w).length > 0
 }
 
-/** The toolbar's two filters, as the view holds them. */
+/** The toolbar's filters, as the view holds them. */
 export interface RosterFilter {
   /** the search box, matched case-insensitively against the target name */
   query: string
@@ -63,17 +63,32 @@ export interface RosterFilter {
   defeatedOnly: boolean
   /** what that switch MEANS in the current view */
   defeated: DefeatedTest
+  /**
+   * Targets the user hid from this tab (issue #32) — LOWERCASED names, the `useQuestFlags`
+   * casing armour (useHiddenTargets.ts owns the set). Optional so the two call shapes that
+   * predate the flag stand unchanged; absent means nothing is hidden.
+   */
+  hidden?: ReadonlySet<string>
+  /**
+   * The "Hidden (n)" toolbar switch: a PEEK, not an un-hide. It stops the drop so the hidden
+   * cards can render (dimmed, carrying the restore control) and consults nothing else.
+   */
+  showHidden?: boolean
 }
 
 /**
- * The roster the view draws: the search box and the defeated switch, in that order of narrowing.
+ * The roster the view draws: the hide flag, then the search box and the defeated switch, in that
+ * order of narrowing. Hidden drops FIRST because it is an identity statement about the roster
+ * ("this card is not my raid week") where the other two are momentary narrowings of it — a
+ * hidden target that matches the search box is still gone.
  *
- * Returns the input array itself when neither filter is on, so an untouched toolbar cannot churn
+ * Returns the input array itself when no filter is on, so an untouched toolbar cannot churn
  * the memoised sectioning below it.
  */
 export function filterRoster(list: TargetStatus[], f: RosterFilter): TargetStatus[] {
   const q = f.query.trim().toLowerCase()
   let out = list
+  if (f.hidden?.size && !f.showHidden) out = out.filter((s) => !f.hidden?.has(s.target.name.toLowerCase()))
   if (f.defeatedOnly) out = out.filter(f.defeated)
   if (q) out = out.filter((s) => s.target.name.toLowerCase().includes(q))
   return out

--- a/src/renderer/src/features/bosses/useHiddenTargets.ts
+++ b/src/renderer/src/features/bosses/useHiddenTargets.ts
@@ -1,0 +1,54 @@
+// TARGETS THE USER HID FROM THE RAID ROSTER (GitHub issue #32) — the fourth flag set in the
+// `useQuestFlags` shape, at yet another granularity: a RAID TARGET, not a quest, a class or an
+// item. It gets its own key for that file's standing reason — one key holding two intents makes
+// one control silently drive the other — and the store is the same factory rather than a fifth
+// copy of it.
+//
+// KEYED BY TARGET NAME, lowercased by the store: the name IS the roster's identity (32 unique
+// names in the bundled data; `match` is log-matching vocabulary, not identity), and the
+// lowercasing is the same casing armour the quest flags state — a future casing drift in the
+// bundled roster must not orphan a user's hides.
+//
+// WHAT HIDING MEANS is rosterFilter.ts's business (the card leaves the roster, the counts, and
+// the tally's denominator; kills and lockouts still record — hiding is display-only). This file
+// owns only the set.
+
+import { useMemo, useState } from 'react'
+import {
+  createQuestFlagStore,
+  useQuestFlagSet,
+  type QuestFlagSet
+} from '../favorites/useQuestFlags'
+import type { TargetStatus } from './bossStatus'
+
+const HIDDEN_KEY = 'eq.bosses.hidden'
+
+const hiddenStore = createQuestFlagStore(HIDDEN_KEY)
+
+/** Raid targets the user hid from the Raid Targets tab, by lowercased target name. */
+export function useHiddenTargets(): QuestFlagSet {
+  return useQuestFlagSet(hiddenStore)
+}
+
+/**
+ * The hide feature's whole view-state, bundled for BossView (which is at the measured
+ * per-function ceiling): the persisted set, the UNPERSISTED peek — "show me what I hid" is a
+ * moment, not a place in the grind, so a fresh mount opens on the roster the user asked for —
+ * and the VISIBLE roster, which is the tally's denominator. A hidden target leaves that
+ * denominator (the Sky tab's rule: a thing the app was told to forget must not be counted
+ * against you), and the peek does not bring it back, because peeking is looking, not un-hiding.
+ */
+export function useHiddenRoster(statuses: TargetStatus[]): {
+  hidden: QuestFlagSet
+  showHidden: boolean
+  setShowHidden: (v: boolean) => void
+  roster: TargetStatus[]
+} {
+  const hidden = useHiddenTargets()
+  const [showHidden, setShowHidden] = useState(false)
+  const roster = useMemo(
+    () => (hidden.size ? statuses.filter((s) => !hidden.has(s.target.name)) : statuses),
+    [statuses, hidden]
+  )
+  return { hidden, showHidden, setShowHidden, roster }
+}

--- a/src/renderer/src/features/favorites/useQuestFlags.ts
+++ b/src/renderer/src/features/favorites/useQuestFlags.ts
@@ -34,7 +34,7 @@ export interface QuestFlagSet {
   size: number
 }
 
-interface QuestFlagStore {
+export interface QuestFlagStore {
   subscribe: (listener: () => void) => () => void
   snapshot: () => Set<string>
   toggle: (questKey: string) => void
@@ -50,7 +50,7 @@ function load(storageKey: string): Set<string> {
   }
 }
 
-function createQuestFlagStore(storageKey: string): QuestFlagStore {
+export function createQuestFlagStore(storageKey: string): QuestFlagStore {
   let current = load(storageKey)
   const listeners = new Set<() => void>()
   return {
@@ -86,7 +86,7 @@ const classFavoriteStore = createQuestFlagStore(CLASS_FAVORITES_KEY)
  * at length — anything that hands one of these down to a row would re-render every row on every
  * keystroke. `store.toggle` is already a module-lifetime function.
  */
-function useQuestFlagSet(store: QuestFlagStore): QuestFlagSet {
+export function useQuestFlagSet(store: QuestFlagStore): QuestFlagSet {
   const keys = useSyncExternalStore(store.subscribe, store.snapshot)
   return useMemo(
     () => ({

--- a/tests/bossHiddenTargets.test.mts
+++ b/tests/bossHiddenTargets.test.mts
@@ -1,0 +1,81 @@
+// HIDE MOBS FROM RAID TARGETS (GitHub issue #32) — the pure half of the roster's hide flag.
+//
+// THE REPORT: "I do not personally see much of a use in displaying all hate minis on the page
+// and even plane of sky could be hideable since it's not effected by the weekly loot as well."
+// "Hate minis" is not a data category — Plane of Hate's twelve targets mix Innoruuk with the
+// minis — so the flag is PER TARGET, a localStorage set of lowercased names in the
+// `useQuestFlags` shape (useHiddenTargets.ts), and the filter is one more input to
+// `filterRoster` (rosterFilter.ts).
+//
+// THE ORDER IS THE DESIGN: hidden drops FIRST, before the search box and the defeated switch,
+// because hiding is an identity statement about the roster ("this card is not my raid week")
+// where the other two are momentary narrowings of it. `showHidden` is a PEEK, not an un-hide:
+// it stops the drop so the cards can render (dimmed, with the restore control) and changes
+// nothing about the set.
+//
+// Same fixtures as tests/bossDefeatedFilter.test.mts — real kill histories, because a
+// hand-built status would assume away the interplay these tests pin (a hidden target that
+// matches the search box must still be gone).
+//
+// Run: `npm test`.
+
+process.env.TZ = 'America/Los_Angeles'
+
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { everDefeated, filterRoster } from '../src/renderer/src/features/bosses/rosterFilter'
+import { history } from './bossHistories.mts'
+
+/** An untouched toolbar, stated once. */
+const none = { query: '', defeatedOnly: false, defeated: everDefeated } as const
+
+test('a hidden target leaves the roster', () => {
+  const list = history()
+  const out = filterRoster(list, { ...none, hidden: new Set(['lord of ire']), showHidden: false })
+  assert.equal(out.length, list.length - 1)
+  assert.ok(!out.some((s) => s.target.name === 'Lord of Ire'))
+})
+
+test('the set holds LOWERCASED names and the filter lowercases before asking', () => {
+  // The same casing armour useQuestFlags states: a data casing drift must not orphan a hide.
+  const list = history()
+  const out = filterRoster(list, { ...none, hidden: new Set(['lord of ire']), showHidden: false })
+  assert.ok(!out.some((s) => s.target.name.toLowerCase() === 'lord of ire'))
+})
+
+test('showHidden is a PEEK: nothing is dropped, and the set is not consulted for membership', () => {
+  const list = history()
+  const out = filterRoster(list, { ...none, hidden: new Set(['lord of ire']), showHidden: true })
+  assert.equal(out, list, 'peeking an otherwise-untouched toolbar hands back the same array')
+})
+
+test('hidden drops FIRST: a hidden target that matches the search box is still gone', () => {
+  const list = history()
+  const out = filterRoster(list, {
+    ...none,
+    query: 'lord of ire',
+    hidden: new Set(['lord of ire']),
+    showHidden: false
+  })
+  assert.equal(out.length, 0, 'the search box cannot resurrect what the user hid')
+})
+
+test('…and the other filters still apply to what survives the hide', () => {
+  const list = history()
+  const out = filterRoster(list, {
+    ...none,
+    defeatedOnly: true,
+    hidden: new Set(['lord of ire']),
+    showHidden: false
+  })
+  assert.ok(out.every((s) => s.killed), 'the defeated switch reads the un-hidden remainder')
+  assert.ok(!out.some((s) => s.target.name === 'Lord of Ire'))
+})
+
+test('an untouched toolbar with an EMPTY hidden set hands back the same array', () => {
+  // The memo-identity promise filterRoster already makes, extended to the new inputs: an empty
+  // set must not churn the sectioning below it.
+  const list = history()
+  assert.equal(filterRoster(list, { ...none, hidden: new Set(), showHidden: false }), list)
+  assert.equal(filterRoster(list, none), list, 'and the fields are optional — old call sites stand')
+})

--- a/tests/e2e/bosses-hide.e2e.mts
+++ b/tests/e2e/bosses-hide.e2e.mts
@@ -1,0 +1,164 @@
+/**
+ * Headless Electron integration test for HIDING RAID TARGETS (GitHub issue #32).
+ *
+ * THE ASK: "I do not personally see much of a use in displaying all hate minis on the page and
+ * even plane of sky could be hideable since it's not effected by the weekly loot as well." The
+ * pure half (hidden drops first, the peek, the case armour) is tests/bossHiddenTargets.test.mts;
+ * what needs a real app is the SURFACE and the LIFECYCLE:
+ *
+ *   1. The card's corner control hides WITHOUT routing — the card's own click opens the mob
+ *      page, so a hide that also navigated would punish the feature's only gesture. Asserted by
+ *      the mode toggle still being mounted after the click.
+ *   2. The tally's DENOMINATOR moves with a hide and does NOT move with the peek — hiding is
+ *      "this card is not my raid week" (it leaves the count), peeking is looking. Two different
+ *      promises, both read off the one toolbar line.
+ *   3. The toolbar switch exists ONLY while something is hidden: a fresh install never sees it.
+ *   4. THE SET SURVIVES A RESTART and THE PEEK DOES NOT — two launches, one userData dir
+ *      through a real process exit. A hide is a standing choice; "show me what I hid" is a
+ *      moment.
+ *
+ * STAGED ON A FIXTURE, unlike bosses-week: a bare `launchApp` leans on a REAL EverQuest install
+ * being auto-discoverable, which is true on the owner's machine and false in most other places —
+ * on a machine with no install the app (rightly) opens on the no-logs-found onboarding and the
+ * Bosses tab never mounts. The roster needs no kills for this spec's subject (a hide is about
+ * CARDS, and undefeated cards are still cards), so any committed fixture do — the telemetry
+ * one is the smallest.
+ *
+ * Run: `npm run test:e2e -- bosses-hide` (or node --import tsx this file).
+ */
+import type { Page } from 'playwright-core'
+import {
+  buildIfStale,
+  check,
+  countOf,
+  dumpArtifacts,
+  failures,
+  reportRun,
+  settle,
+  settleGone
+} from './appHarness.mjs'
+import { mainWindow, makeUserData, removeUserData } from './appWindow.mjs'
+import { launchOnFixture, stageFixture } from './logFixture.mjs'
+
+const NAV_OVERVIEW = '[data-testid="nav-overview"]'
+const NAV_BOSSES = '[data-testid="nav-bosses"]'
+const MODE = '[data-testid="boss-mode"]'
+const CARD = '[data-testid="boss-card"]'
+const HIDE = '[data-testid="boss-card-hide"]'
+const SHOW_HIDDEN = '[data-testid="boss-show-hidden"]'
+const TALLY = '[data-testid="boss-tally"]'
+
+async function openBosses(page: Page): Promise<boolean> {
+  await page.click(NAV_BOSSES, { timeout: 30_000 })
+  return page.waitForSelector(MODE, { timeout: 60_000 }).then(
+    () => true,
+    () => false
+  )
+}
+
+/** The tally's denominator — `<n> / <total> defeated · …` on the overall view. */
+async function tallyTotal(page: Page): Promise<number | null> {
+  const text = (await page.textContent(TALLY, { timeout: 15_000 })) ?? ''
+  const m = /\/ (\d+) defeated/.exec(text)
+  return m ? Number(m[1]) : null
+}
+
+/** The switch's checked state, or null while it is not mounted at all. */
+function peekState(page: Page): Promise<boolean | null> {
+  return page.evaluate((sel) => {
+    const input = document.querySelector<HTMLInputElement>(`${sel} input`)
+    return input ? input.checked : null
+  }, SHOW_HIDDEN)
+}
+
+async function stepHideOneCard(page: Page): Promise<{ cards: number; total: number } | null> {
+  const cards = await countOf(page, CARD)
+  const total = await tallyTotal(page)
+  if (!check('the roster reads cleanly before anything is hidden', cards > 0 && total !== null)) return null
+  check('a fresh install has NO Hidden switch at all', (await peekState(page)) === null)
+
+  await page.click(`${CARD} ${HIDE}`, { timeout: 15_000 })
+  const after = await settle(() => countOf(page, CARD), (n) => n === cards - 1, { timeoutMs: 8_000 })
+  check('the card leaves the roster', after === cards - 1, `${String(after)} of ${String(cards)}`)
+  check('…without routing to the mob page (the toolbar is still here)', (await countOf(page, MODE)) === 1)
+  check('THE DENOMINATOR MOVES: a hidden target leaves the tally', (await tallyTotal(page)) === (total ?? 0) - 1)
+  check('and the Hidden switch appears, off', (await peekState(page)) === false)
+  return { cards, total: total ?? 0 }
+}
+
+async function stepPeekAndRestore(page: Page, base: { cards: number; total: number }): Promise<void> {
+  await page.click(SHOW_HIDDEN, { timeout: 15_000 })
+  const shown = await settle(() => countOf(page, CARD), (n) => n === base.cards, { timeoutMs: 8_000 })
+  check('THE PEEK: every card renders again', shown === base.cards)
+  check('…but the denominator does NOT move — peeking is looking, not un-hiding',
+    (await tallyTotal(page)) === base.total - 1)
+
+  // The hidden card is the one whose control now offers UNHIDE; clicking it restores the target.
+  await page.click(`${CARD} [aria-label^="unhide "]`, { timeout: 15_000 })
+  const gone = await settleGone(page, SHOW_HIDDEN, { timeoutMs: 8_000 })
+  check('unhide empties the set and the switch leaves the toolbar with it', gone)
+  check('…and the tally is whole again', (await tallyTotal(page)) === base.total)
+}
+
+async function main(): Promise<void> {
+  await buildIfStale()
+  const userData = makeUserData()
+  // Staged ONCE and handed to both launches (an owned fixture would be disposed by launch 1's
+  // close, taking the install out from under the restart).
+  const log = stageFixture('e2e-telemetry.log')
+  try {
+    console.log('launch 1: a fresh install — hide, the peek, the restore, then arm the restart…')
+    const first = await launchOnFixture(log, { userData })
+    let page: Page | null = null
+    let base: { cards: number; total: number } | null = null
+    try {
+      page = await mainWindow(first.app)
+      await page.waitForSelector(NAV_OVERVIEW, { timeout: 60_000 })
+      if (!check('the Bosses tab opens', await openBosses(page))) {
+        throw new Error('never reached the Bosses tab - nothing below can be asserted')
+      }
+      base = await stepHideOneCard(page)
+      if (base) {
+        await stepPeekAndRestore(page, base)
+        // Arm the restart: hide one card again and leave the peek wherever it lies — the set
+        // must come back, the peek must not.
+        await page.click(`${CARD} ${HIDE}`, { timeout: 15_000 })
+        await settle(() => peekState(page as Page), (v) => v === false || v === true, { timeoutMs: 8_000 })
+      }
+      if (failures.length) await dumpArtifacts(page, 'bosses-hide-FAIL')
+    } finally {
+      await first.close()
+    }
+
+    if (base) {
+      console.log('launch 2: the SAME userData dir, a new process — the SET survives, the PEEK does not…')
+      const second = await launchOnFixture(log, { userData })
+      let restarted: Page | null = null
+      try {
+        restarted = await mainWindow(second.app)
+        await restarted.waitForSelector(NAV_OVERVIEW, { timeout: 60_000 })
+        if (check('the Bosses tab opens again', await openBosses(restarted))) {
+          const cards = await settle(() => countOf(restarted as Page, CARD), (n) => n === base.cards - 1, {
+            timeoutMs: 8_000
+          })
+          check('THE HIDE SURVIVED THE RESTART', cards === base.cards - 1, `${String(cards)} cards`)
+          check('…and the peek came back OFF: a hide is standing, a peek is a moment',
+            (await peekState(restarted)) === false)
+        }
+        if (failures.length) await dumpArtifacts(restarted, 'bosses-hide-restart-FAIL')
+      } finally {
+        await second.close()
+      }
+    }
+  } finally {
+    await log.dispose()
+    await removeUserData(userData)
+  }
+
+  reportRun()
+}
+
+main().catch((err: unknown) => {
+  console.error('e2e: harness error -', err)
+  process.exitCode = 1
+})


### PR DESCRIPTION
Fixes #32 — hiding hate minis (and anything else) from the Raid Targets roster.

## The shape

"Hate minis" is not a data category — Plane of Hate's twelve targets mix Innoruuk with the minis — so the flag is **per target**: a fourth localStorage set in the `useQuestFlags` shape (`eq.bosses.hidden`, lowercased names, the same factory exported rather than a fifth copy of it), toggled from a corner control on the card. The control stops the click, so hiding never also routes to the mob page; it sits top-right because the kill badge owns top-left.

## The rules, and where they come from

- **Hidden drops first** in `filterRoster`, before the search box and the defeated switch: hiding is an identity statement about the roster where the other two are momentary narrowings — the search box cannot resurrect what the user hid.
- **The tally's denominator is the visible roster.** The tally's standing rule ("counts the whole roster, never `filtered` — it must not move when a switch is flipped") holds; what changes is what the roster *is*. A hidden target leaves the denominator on the Sky tab's rule — a thing the app was told to forget must not be counted against you. This is half the reporter's actual complaint: minis skewing the progression count.
- **The toolbar's `Hidden (n)` switch is a peek, not an un-hide**: drawn only while something is hidden, it renders the hidden cards dimmed with their restore control, and the denominator stays put — peeking is looking. The peek is deliberately unpersisted where the set persists: a hide is a standing choice, "show me what I hid" is a moment.
- **Hiding is display-only**: kills, lockouts, and confetti still record.

Both modes (overall/week) and both groupings (category/loadout) read the one filtered roster — no special-casing. `BossSections` and `BossView` were at their measured ceilings, so the card's two corner controls moved to `cardCorners.tsx` and the hide view-state bundled into `useHiddenRoster` — the JOS-389 medicine.

## Tests

- `tests/bossHiddenTargets.test.mts` — the pure half over the real kill-history fixtures: hidden drops first, the peek drops nothing, the casing armour, and the memo-identity promise extended to the new inputs (old call shapes stand — the fields are optional).
- `tests/e2e/bosses-hide.e2e.mts` — the surface and the lifecycle in a real app: hide without routing, the denominator moving on hide and NOT on peek, the switch existing only while something is hidden, and a two-launch restart proving the set survives where the peek does not.

## A finding your e2e machine won't have shown you

The new spec stages a fixture install (`logFixture`) rather than bare-launching — and that difference is why **`bosses-week.e2e.mts` and `sky-filters.e2e.mts` currently fail on any machine without a real EverQuest install** (both bare-`launchApp`, so the app rightly opens on the no-logs-found onboarding and the tab under test never mounts; every fixture-staged spec passes on the same machine). Verified against clean `main` here (macOS, no EQ install). Happy to send a follow-up PR staging those two specs onto fixtures if useful.

## Verification (macOS)

- `npm run typecheck` — pass; `npm run lint` — pass
- `npm test` — 5218/5259; the 4 failures are the platform-dependent set that fails identically on clean `main` here (one is #23's subject)
- `npm run test:e2e -- bosses-hide` — all checks green, ~4 s

🤖 Generated with [Claude Code](https://claude.com/claude-code)