### PR TITLE
E2e portability + PR CI: two specs stop betting on a real install, and pull requests get the verify gate

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,15 @@
 #                         can never ship a mismatched package.json version and
 #                         "remember to bump after tagging" is no longer a rule.
 #
+#   pull_request        → typecheck + lint + test + a bare `npm run build`, and
+#                         NOTHING else: no installer, no artifacts, no secrets
+#                         touched. Until this job existed a PR got no CI at all —
+#                         the checks lived on the main-branch push AFTER a merge,
+#                         which is the wrong side of the decision they inform.
+#                         GitHub hands a fork PR a read-only token and withholds
+#                         repo secrets by design; this job is shaped so that even
+#                         that token has nothing to write.
+#
 # THOSE TWO PATHS ARE TWO SEPARATE JOBS, and that split is a SECURITY boundary,
 # not cosmetics. GITHUB_TOKEN permissions are per-job and static — they cannot be
 # made conditional inside a job — so a single job covering both paths had to hold
@@ -66,6 +75,7 @@ on:
   push:
     branches: [main]
     tags: ['v*']
+  pull_request:
   workflow_dispatch:
 
 # Least privilege at the top: no job gets a token scope it does not name.
@@ -75,10 +85,54 @@ permissions: {}
 
 jobs:
   # =========================================================================
-  # NON-TAG REFS: verify + build. Read-only token. Publishes NOTHING.
+  # PULL REQUESTS: the verify gate and nothing else. Read-only token, no
+  # secrets, no artifacts — a fork's code runs here, so the job is shaped to
+  # have nothing worth taking. The prelude is duplicated on purpose (header).
+  # =========================================================================
+  verify:
+    if: ${{ github.event_name == 'pull_request' }}
+    runs-on: windows-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4 (v4.4.0)
+        with:
+          persist-credentials: false
+
+      - name: Setup Node
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4 (v4.4.0)
+        with:
+          node-version: 24 # see the build job for why not 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Electron binary
+        run: npm run deps:electron
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      # See the build job for what this gate is and why it is green.
+      - name: Lint
+        run: npm run lint
+
+      - name: Test
+        run: npm test
+
+      # The bare electron-vite build (NOT electron-builder): catches a PR that
+      # typechecks but cannot bundle, in ~30s, without minting an installer
+      # nobody will run from a PR.
+      - name: Build
+        run: npm run build
+
+  # =========================================================================
+  # MAIN-BRANCH PUSHES: verify + build. Read-only token. Publishes NOTHING.
   # =========================================================================
   build:
-    if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
+    if: ${{ github.event_name != 'pull_request' && !startsWith(github.ref, 'refs/tags/v') }}
     runs-on: windows-latest
     permissions:
       contents: read

--- a/tests/e2e/bosses-week.e2e.mts
+++ b/tests/e2e/bosses-week.e2e.mts
@@ -46,6 +46,16 @@
  * `makeUserData()` hands both launches the same dir, so launch 2 reads the localStorage launch 1
  * wrote through a real process exit.
  *
+ * STAGED ON A FIXTURE since the portability fix: this spec used to bare-`launchApp`, which leans
+ * on a REAL EverQuest install being auto-discoverable — true on the owner's machine, false in
+ * most other places, where the app (rightly) opened on the no-logs-found onboarding and the
+ * Bosses tab never mounted, so the whole spec red before its first assertion. The committed
+ * telemetry fixture is enough on its own: its `You have slain Lord Nagafen!` is a roster kill,
+ * which gives the defeated filter something real to keep and the by-loadout view its one honest
+ * `unknown` section (a kill no combo interval covers). Nothing this spec asserts wants more —
+ * WHICH rungs are green is deliberately not asserted (the header's rule), so the fixture's fixed
+ * dates cannot rot it.
+ *
  * WHY IT NEVER TAKES THE SCREEN: `EQ_E2E=1` (src/main/e2e.ts) shows no window, skips the
  * single-instance lock, and points `userData` at a throwaway temp dir per launch.
  *
@@ -65,7 +75,8 @@ import {
   settleStable,
   waitHydrated
 } from './appHarness.mjs'
-import { launchApp, mainWindow, makeUserData, removeUserData } from './appWindow.mjs'
+import { mainWindow, makeUserData, removeUserData } from './appWindow.mjs'
+import { launchOnFixture, stageFixture } from './logFixture.mjs'
 import { stepLoadoutSectionsAreHonest } from './loadoutSectionSteps.mjs'
 
 const NAV_BOSSES = '[data-testid="nav-bosses"]'
@@ -616,9 +627,12 @@ async function main(): Promise<void> {
   // OWNED BY THIS SPEC, not by either launch: the restart assertion IS the dir outliving a
   // process, so `launchApp` must not delete what it did not create.
   const userData = makeUserData()
+  // Staged ONCE and handed to both launches (an owned fixture would be disposed by launch 1's
+  // close, taking the install out from under the restart half).
+  const log = stageFixture('e2e-telemetry.log')
   try {
     console.log('launch 1: a fresh install - the default, the ladder, and both round trips…')
-    const first = await launchApp({ userData })
+    const first = await launchOnFixture(log, { userData })
     let page: Page | null = null
     try {
       page = await mainWindow(first.app)
@@ -637,7 +651,7 @@ async function main(): Promise<void> {
     }
 
     console.log('launch 2: the SAME userData dir, a new process - This week must still be there…')
-    const second = await launchApp({ userData })
+    const second = await launchOnFixture(log, { userData })
     let restarted: Page | null = null
     try {
       restarted = await mainWindow(second.app)
@@ -648,6 +662,7 @@ async function main(): Promise<void> {
       await second.close()
     }
   } finally {
+    await log.dispose()
     await removeUserData(userData)
   }
 

--- a/tests/e2e/bosses-week.e2e.mts
+++ b/tests/e2e/bosses-week.e2e.mts
@@ -71,15 +71,15 @@ import {
   note,
   reportRun,
   settle,
-  settleGone,
   settleStable,
   waitHydrated
 } from './appHarness.mjs'
 import { mainWindow, makeUserData, removeUserData } from './appWindow.mjs'
 import { launchOnFixture, stageFixture } from './logFixture.mjs'
 import { stepLoadoutSectionsAreHonest } from './loadoutSectionSteps.mjs'
+// The tab round trip, out of this file for the ceiling's sake — see its header.
+import { awayAndBack, openBosses } from './bossesNav.mjs'
 
-const NAV_BOSSES = '[data-testid="nav-bosses"]'
 const NAV_OVERVIEW = '[data-testid="nav-overview"]'
 /** The toggle group under test, and its two buttons. */
 const MODE = '[data-testid="boss-mode"]'
@@ -388,30 +388,8 @@ async function stepDefeatedOnlyIsAllTime(page: Page): Promise<number> {
 }
 
 /** Open the Bosses tab and wait for its toolbar. Safe when the tab is already the open one. */
-async function openBosses(page: Page, timeoutMs = 60_000): Promise<boolean> {
-  await page.click(NAV_BOSSES, { timeout: 30_000 })
-  return page.waitForSelector(MODE, { timeout: timeoutMs }).then(
-    () => true,
-    () => false
-  )
-}
 
-/**
- * Leave for another tab, and confirm the Bosses view is really gone. This is the step the bug
- * lived in: the assertion after it means nothing unless `BossView` was actually unmounted here.
- */
-async function leaveBosses(page: Page): Promise<boolean> {
-  await page.click(NAV_OVERVIEW, { timeout: 30_000 })
-  return settleGone(page, MODE, { timeoutMs: 15_000 })
-}
 
-/** Away to the Overview and back to Bosses, with the unmount actually asserted in between. */
-async function awayAndBack(page: Page): Promise<boolean> {
-  if (!check('leaving the Bosses tab unmounts it (the mode toggle is gone)', await leaveBosses(page))) {
-    return false
-  }
-  return check('…and the Bosses tab comes back', await openBosses(page))
-}
 
 /** Click a mode button and wait for the group to report the mode we asked for. */
 async function setMode(page: Page, button: string, want: string): Promise<string | null> {

--- a/tests/e2e/bossesNav.mts
+++ b/tests/e2e/bossesNav.mts
@@ -1,0 +1,42 @@
+// THE BOSSES TAB ROUND TRIP — the navigation bracket bosses-week wraps every assertion in, out
+// of that file because it is at the 400-code-line ceiling (the same move, for the same reason,
+// as loadoutSectionSteps.mts). The trip OUT asserts the toolbar is really gone first: the
+// remembered-tab bug lived in the unmount, so an assertion after a navigation that never
+// unmounted anything would be a tautology (bosses-week's header carries the whole argument).
+//
+// Selectors are spelled again rather than imported: this file must not make bosses-week export
+// its constants (loadoutSectionSteps' rule).
+
+import type { Page } from 'playwright-core'
+import { check } from './appHarness.mjs'
+import { settleGone } from './settle.mjs'
+
+const NAV_BOSSES = '[data-testid="nav-bosses"]'
+const NAV_OVERVIEW = '[data-testid="nav-overview"]'
+const MODE = '[data-testid="boss-mode"]'
+
+/** Open the Bosses tab and wait for its toolbar. Safe when the tab is already the open one. */
+export async function openBosses(page: Page, timeoutMs = 60_000): Promise<boolean> {
+  await page.click(NAV_BOSSES, { timeout: 30_000 })
+  return page.waitForSelector(MODE, { timeout: timeoutMs }).then(
+    () => true,
+    () => false
+  )
+}
+
+/**
+ * Leave for another tab, and confirm the Bosses view is really gone. This is the step the bug
+ * lived in: the assertion after it means nothing unless `BossView` was actually unmounted here.
+ */
+export async function leaveBosses(page: Page): Promise<boolean> {
+  await page.click(NAV_OVERVIEW, { timeout: 30_000 })
+  return settleGone(page, MODE, { timeoutMs: 15_000 })
+}
+
+/** Away to the Overview and back to Bosses, with the unmount actually asserted in between. */
+export async function awayAndBack(page: Page): Promise<boolean> {
+  if (!check('leaving the Bosses tab unmounts it (the mode toggle is gone)', await leaveBosses(page))) {
+    return false
+  }
+  return check('…and the Bosses tab comes back', await openBosses(page))
+}

--- a/tests/e2e/sky-filters.e2e.mts
+++ b/tests/e2e/sky-filters.e2e.mts
@@ -77,7 +77,8 @@ import {
   settleGone,
   settleStable
 } from './appHarness.mjs'
-import { launchApp, mainWindow, makeUserData, removeUserData } from './appWindow.mjs'
+import { mainWindow, makeUserData, removeUserData } from './appWindow.mjs'
+import { launchOnFixture, stageFixture } from './logFixture.mjs'
 // The remount guard (JOS-279) — see `skyMount` below and that module's header for the argument.
 import { mountGuard, type MountGuard } from './viewRemount.mjs'
 
@@ -171,12 +172,18 @@ function expandedNames(page: Page): Promise<string[]> {
  * THE PRECONDITION EVERY EXPANDED-ROW ASSERTION IN THIS FILE RESTS ON, and which for six ledgered
  * runs was left to luck (AGENTS.md's flake ledger; fixed in JOS-279).
  *
- * This spec launches against the machine's OWN growing log rather than a staged fixture, so the
- * `viewKey` rebuilds `App` pushes as the historical fold lands arrive while the spec is already
- * driving the tab — and a rebuild remounts `PoskyView`, which closes an accordion the step opened
- * one line ago. That is correct app behaviour and a false failure: the steps below ask whether
- * FAVORITING collapses the list and whether CLOSING a panel unmounts it, never whether a character
- * rebuild does. `viewRemount.mts` carries the whole argument and the vocabulary.
+ * This spec USED to launch against the machine's own growing log, so the `viewKey` rebuilds
+ * `App` pushes as the historical fold lands arrive while the spec is already driving the tab —
+ * and a rebuild remounts `PoskyView`, which closes an accordion the step opened one line ago.
+ * That is correct app behaviour and a false failure: the steps below ask whether FAVORITING
+ * collapses the list and whether CLOSING a panel unmounts it, never whether a character rebuild
+ * does. `viewRemount.mts` carries the whole argument and the vocabulary.
+ *
+ * The spec is staged on a fixture now (the portability fix — a bare launch needs a REAL install
+ * to be discoverable, and on a machine without one the Sky tab never mounted at all). A small
+ * fixed log makes the guard's job easy, but the guard STAYS: it is the stated precondition of
+ * every expanded-row step, six ledgered flakes say what its absence costs, and the fold of even a
+ * small log still lands while launch-adjacent steps run.
  *
  * The anchor is the Sky tab's own sub-tab strip: inside the keyed subtree, and mounted whichever
  * sub-tab is showing.
@@ -668,9 +675,13 @@ async function main(): Promise<void> {
   // OWNED BY THIS SPEC, not by either launch: the restart assertion IS the dir outliving a
   // process, so `launchApp` must not delete what it did not create.
   const userData = makeUserData()
+  // Staged ONCE and handed to both launches (an owned fixture would be disposed by launch 1's
+  // close, taking the install out from under the restart half). The Sky tab's subject is BUNDLED
+  // data — quests, islands, bosses — so the smallest committed fixture is enough to boot on.
+  const log = stageFixture('e2e-telemetry.log')
   try {
     console.log('launch 1: a fresh install — default, tab round trip, the un-tick, the pair, and the facets…')
-    const first = await launchApp({ userData })
+    const first = await launchOnFixture(log, { userData })
     let page: Page | null = null
     try {
       page = await mainWindow(first.app)
@@ -709,7 +720,7 @@ async function main(): Promise<void> {
     }
 
     console.log('launch 2: the SAME userData dir, a new process — the tick must still be there…')
-    const second = await launchApp({ userData })
+    const second = await launchOnFixture(log, { userData })
     let restarted: Page | null = null
     try {
       restarted = await mainWindow(second.app)
@@ -720,6 +731,7 @@ async function main(): Promise<void> {
       await second.close()
     }
   } finally {
+    await log.dispose()
     await removeUserData(userData)
   }
 

--- a/tests/e2e/sky-filters.e2e.mts
+++ b/tests/e2e/sky-filters.e2e.mts
@@ -79,6 +79,9 @@ import {
 } from './appHarness.mjs'
 import { mainWindow, makeUserData, removeUserData } from './appWindow.mjs'
 import { launchOnFixture, stageFixture } from './logFixture.mjs'
+// The FIFTH copy of this consolidated away — levelingLayoutSteps' own comment called the fourth
+// "a consolidation ticket, not a reason to skip it".
+import { dismissFirstRunNotice } from './levelingLayoutSteps.mjs'
 // The remount guard (JOS-279) — see `skyMount` below and that module's header for the argument.
 import { mountGuard, type MountGuard } from './viewRemount.mjs'
 
@@ -222,19 +225,6 @@ async function clearPick(page: Page, picker: string): Promise<void> {
   await page.keyboard.press('Escape')
 }
 
-/**
- * Answer the analytics first-run notice, which a FRESH userData always shows and which sits at the
- * BOTTOM CENTRE of the window until it is answered — directly over the list footer JOS-191's steps
- * click. Nothing in this file cares about analytics, so "turn it off" is the quiet answer (the perf
- * and text-size specs make the same call for the same reason).
- */
-async function dismissFirstRunNotice(page: Page): Promise<void> {
-  const notice = '[data-testid="telemetry-notice"]'
-  await page.waitForSelector(notice, { timeout: 30_000 }).catch(() => undefined)
-  if ((await countOf(page, notice)) === 0) return
-  await page.click('[data-testid="telemetry-notice-off"]')
-  check('the analytics first-run notice can be answered out of the way', await settleGone(page, notice, { timeoutMs: 8_000 }))
-}
 
 /** Open the Sky tab and wait for its toolbar. Safe when the tab is already the open one. */
 async function openSky(page: Page, timeoutMs = 60_000): Promise<boolean> {


### PR DESCRIPTION
Two commits, one theme: contributor-grade verification. (Follow-up offered in #47's notes.)

## 1. `bosses-week` and `sky-filters` stage a fixture

Both specs bare-`launchApp`'d, which leans on a **real EverQuest install being auto-discoverable** — true on the owner's machine, false in most other places, where the app (rightly) opens on the no-logs-found onboarding, the tab under test never mounts, and each spec reds at its first assertion after a 60-second timeout. They were the only tab specs left on the bare launch; every fixture-staged spec passes on the same machine.

The committed telemetry fixture is enough for both, so **no new fixture bytes**:

- For `bosses-week`, its `You have slain Lord Nagafen!` is a roster kill — the defeated filter gets something real to keep, and the by-loadout view gets its one honest `unknown` section (a kill no combo interval covers). WHICH rungs are green is deliberately not asserted (the spec's own rule), so the fixture's fixed dates cannot rot it.
- For `sky-filters`, the tab's subject is bundled data. The JOS-279 mount guard stays, with its comment updated to say why: it is the stated precondition of the expanded-row steps, and the fold of even a small log still lands while launch-adjacent steps run.

The staged log is created once and handed to both launches, so the restart halves still span a real process exit.

**Result on a machine with no EQ install:** both specs go from a 60s timeout to green in ~8s each. Full suite here: **51/54** (from 49/54); the three still red — `combat-dashboard`, `close-to-tray`, `buffs-overlay` — fail identically on clean `main` (overlay/tray geometry on macOS, a different family, out of this PR's scope).

## 2. Pull requests get the verify gate

`build.yml` runs only on pushes to `main` and `v*` tags — a PR gets **no CI at all**, so the checks live on the wrong side of the decision they inform. With four-plus active contributor branches open right now, this is the cheapest quality lever in the repo.

Shaped to the file's own security posture: a **third job**, not a trigger bolted onto `build`, because the two-job split is a stated security boundary and a fork PR is the least trusted ref this workflow will ever run. `verify` has nothing worth taking — per-job read-only token, no secrets referenced, no artifacts uploaded, actions pinned to the same SHAs, and a bare `npm run build` (electron-vite, ~30s) instead of electron-builder, so a PR that typechecks but cannot bundle still fails without minting an installer. The prelude is duplicated per the header's standing rule, and `build`'s guard grows the event-name half so a PR runs exactly one job.

Once this and the spec staging land, a natural follow-up is an e2e job on PRs too — the suite is now install-independent end to end (the 3 macOS reds are platform, not fixtures, and CI is `windows-latest`).

## Verification (macOS, no EQ install)

- `npm run typecheck` — pass; `npm run lint` — pass
- Converted specs: `sky-filters` 9.1s ok, `bosses-week` 7.4s ok (both previously 60s timeouts, on this branch and on clean main)
- Full e2e suite: 51/54, the 3 failures pre-existing on clean main
- Workflow YAML validated; guards are mutually exclusive per event

🤖 Generated with [Claude Code](https://claude.com/claude-code)