### PR TITLE
feature: multiple map markers, and automatic player loc update

### DIFF
--- a/src/main/log/parseWorld.ts
+++ b/src/main/log/parseWorld.ts
@@ -124,6 +124,15 @@ const LOOT_COMBINE_RE = /^You looted (?:(\d+) |an? )?(.+?) from (.+?) corpse to 
 const DESTROY_RE = /^You successfully destroyed (\d+) (.+?)\.$/
 
 const ZONE_RE = /^You have entered (.+?)\.$/
+
+// `/loc` — `Your Location is 1467.76, 1141.96, 164.72` (JOS-98 wave 2). The one positional line the
+// log carries, and only when the command is typed. Anchored at both ends and gated on the whole
+// `Your Location is ` prefix: the message reaches this classifier with its `[timestamp] ` already
+// stripped, so a chat line quoting the sentence begins with the speaker's name and can never reach
+// it. Three signed decimals, comma-and-space separated, optional trailing period — the exact shape
+// the game prints and the wiki records (locMarker.ts carries the evidence). NS first, then EW, then
+// elevation (never negated); `mapGeometry.mapFromLoc` owns the transform to map coordinates.
+const LOC_RE = /^Your Location is (-?\d+(?:\.\d+)?), (-?\d+(?:\.\d+)?), (-?\d+(?:\.\d+)?)\.?$/
 // Pseudo-zone notices that share the "You have entered <X>." grammar but are NOT
 // real zone transitions. Emitting a zone event for these wipes the tracked zone
 // (so the kills module computes tier 0 for everything killed inside an instance)
@@ -390,6 +399,18 @@ export function classifyZone({ text, ts, seq, raw }: ClassifyCtx): LogEvent | nu
     if (m && !PSEUDO_ZONE_RE.test(m[1])) return { kind: 'zone', seq, ts, raw, zone: m[1].trim() }
   }
   return null
+}
+
+/**
+ * `/loc` (JOS-98 wave 2). Gated on the `Your Location is ` prefix so the common line pays one
+ * length-guarded compare. Emits the reading in the game's own order (ns, ew, z); the maps feature
+ * moves its marker on it through the character module.
+ */
+export function classifyLoc({ text, ts, seq, raw }: ClassifyCtx): LogEvent | null {
+  if (!text.startsWith('Your Location is ')) return null
+  const m = LOC_RE.exec(text)
+  if (!m) return null
+  return { kind: 'loc', seq, ts, raw, loc: { ns: Number(m[1]), ew: Number(m[2]), z: Number(m[3]) } }
 }
 
 /** Self-loot, including the auto-disposition variants — and the destroy, which is the negative. */

--- a/src/main/log/parser.ts
+++ b/src/main/log/parser.ts
@@ -66,6 +66,7 @@ import {
   classifyExp,
   classifyItemMerge,
   classifyLevel,
+  classifyLoc,
   classifyLoot,
   classifyAaPotion,
   classifyTurnIn,
@@ -141,6 +142,11 @@ const CLASSIFIERS: readonly Classifier[] = [
   classifyAllyPetLeader,
   classifyDeath,
   classifyZone,
+  // WHERE ON THE MAP (JOS-98 wave 2) — `Your Location is …`. Beside `zone` because it is the same
+  // subject one notch finer, and gated on a `Your Location is ` prefix; the whole log holds a
+  // handful of these and every one was `{kind:'unknown'}` before this entry, so it can neither
+  // shadow nor be shadowed and the position is for legibility.
+  classifyLoc,
   // SESSION frame (login / camp-out / camp-abort). Beside the zone rule because they answer
   // the same question one level up — zone says WHERE you are, these say WHETHER you are in
   // the world at all — and because a Welcome is always followed within 0–1 lines by a zone

--- a/src/main/modules/character.ts
+++ b/src/main/modules/character.ts
@@ -35,6 +35,8 @@ export class CharacterModule implements EqModule<CharacterSnap, CharacterDelta> 
   private character: CharacterRef | null = null
   private zone: string | undefined
   private level: LevelStatement | undefined
+  /** The last LIVE `/loc`, cleared on every zone change — see CharacterSnap.loc for why transient. */
+  private loc: CharacterSnap['loc']
   /** See the header: the module's OWN revision, monotonic for the life of the process. */
   private rev = 0
   private pending: CharacterDelta = {}
@@ -45,6 +47,7 @@ export class CharacterModule implements EqModule<CharacterSnap, CharacterDelta> 
     // character switch must not carry the previous character's zone or level into the new one.
     this.zone = undefined
     this.level = undefined
+    this.loc = undefined
     this.pending = {}
     this.rev++
   }
@@ -56,12 +59,15 @@ export class CharacterModule implements EqModule<CharacterSnap, CharacterDelta> 
     this.rev++
   }
 
-  onEvent(ev: LogEvent): void {
+  // `live` defaults to false so a one-arg caller (the unit tests, and any direct driver) gets
+  // replay semantics — the /loc auto-place is a LIVE-only effect, and false is the safe read.
+  onEvent(ev: LogEvent, live = false): void {
     if (ev.kind === 'epoch') {
       // Character rebirth (epochDetector.ts): the level and zone of the wiped character say
       // nothing about this one. The ref is index.ts's and stays.
       this.zone = undefined
       this.level = undefined
+      this.clearLoc()
       this.pending.zone = undefined
       this.pending.level = undefined
       this.rev++
@@ -70,6 +76,21 @@ export class CharacterModule implements EqModule<CharacterSnap, CharacterDelta> 
     if (ev.kind === 'zone' && ev.zone !== this.zone) {
       this.zone = ev.zone
       this.pending.zone = ev.zone
+      // A /loc reading belongs to the zone it was taken in; leaving that zone retires it, so the
+      // reading you took in East Freeport can never place a crosshair on the Commonlands map you
+      // just walked into. Pushing `loc: undefined` (not erasing the marker) is what a consumer
+      // reads as "nothing to auto-place now" — see CharacterSnap.loc.
+      this.clearLoc()
+      this.rev++
+      return
+    }
+    // WHERE YOU ARE (JOS-98 wave 2), LIVE ONLY. The historical replay folds /loc lines like every
+    // other module (the `live` flag gates nothing in the fold itself) but must NOT set this: a /loc
+    // from days ago would otherwise place a marker on launch and overwrite the one you typed by
+    // hand. So the guard is here, at the one field where a stale value would be user-visible.
+    if (ev.kind === 'loc' && live) {
+      this.loc = ev.loc
+      this.pending.loc = ev.loc
       this.rev++
       return
     }
@@ -103,10 +124,17 @@ export class CharacterModule implements EqModule<CharacterSnap, CharacterDelta> 
     this.rev++
   }
 
+  /** Drop the last /loc, staging the clear only when there was one to drop. Callers own the rev. */
+  private clearLoc(): void {
+    if (this.loc === undefined) return
+    this.loc = undefined
+    this.pending.loc = undefined
+  }
+
   snapshot(): { seq: number; state: CharacterSnap } {
     return {
       seq: this.rev,
-      state: { character: this.character, zone: this.zone, level: this.level }
+      state: { character: this.character, zone: this.zone, level: this.level, loc: this.loc }
     }
   }
 

--- a/src/renderer/src/features/maps/MapBody.tsx
+++ b/src/renderer/src/features/maps/MapBody.tsx
@@ -33,6 +33,7 @@ import { MapLocMarker } from './MapLocMarker'
 import MapMobPane from './MapMobPane'
 import { paneOverlay, type PaneOverlay, type ZonePaneState } from './useMapPane'
 import { mapFromLoc, type EqLoc, type LayerMask } from './mapGeometry'
+import type { TypedMarker } from './locMarker'
 import { bandRange, type FloorBand } from './floorSlice'
 import type { MapViewport } from './useMapViewport'
 import { Tooltip } from '../../lib/Tooltip'
@@ -162,7 +163,8 @@ function MapSurface({
   bands,
   floor,
   marker,
-  locMarker,
+  typedMarkers,
+  playerMarker,
   pane
 }: {
   data: MapData
@@ -172,8 +174,10 @@ function MapSurface({
   bands: readonly FloorBand[]
   floor: number | null
   marker: Marker | null
-  /** The `/loc` the user typed for THIS zone, still in the game's own axes (JOS-98). */
-  locMarker: EqLoc | null
+  /** The `/loc`s the user TYPED for THIS zone (up to four, coloured), in the game's own axes. */
+  typedMarkers: readonly TypedMarker[]
+  /** The `/loc` the LOG scraped for THIS zone (light red) — where the character stood. */
+  playerMarker: EqLoc | null
   /** The sidebar's contribution, or null when it is closed and draws nothing. */
   pane: PaneOverlay | null
 }): JSX.Element {
@@ -209,9 +213,13 @@ function MapSurface({
       {pane != null && <MapMobPins pins={pane.pins} vp={vp} selectedId={pane.selectedId} />}
       {ringAt != null && <MarkerRing at={ringAt} size={26} testId="maps-pane-marker" />}
       {at != null && <MarkerRing at={at} size={22} testId="maps-marker" />}
-      {/* THE ONE SEAM, AGAIN: the typed reading reaches the screen through `mapFromLoc` and then
-          the same `project` every other mark uses. Nothing here knows which way north is. */}
-      {locMarker != null && <MapLocMarker at={mapFromLoc(locMarker)} loc={locMarker} vp={vp} />}
+      {/* THE ONE SEAM, AGAIN: each reading reaches the screen through `mapFromLoc` and then the
+          same `project` every other mark uses. Nothing here knows which way north is. The player
+          crosshair draws first so a pasted mark sitting on the same spot stays on top. */}
+      {playerMarker != null && <MapLocMarker variant="player" at={mapFromLoc(playerMarker)} loc={playerMarker} vp={vp} />}
+      {typedMarkers.map((m) => (
+        <MapLocMarker key={m.color} variant={m.color} at={mapFromLoc(m.loc)} loc={m.loc} vp={vp} />
+      ))}
     </Box>
   )
 }
@@ -254,15 +262,17 @@ export interface MapBodyProps {
   /** The LONG zone name the catalog was joined on, for the sidebar's own honesty. */
   zoneName: string | null
   marker: Marker | null
-  /** This zone's typed-/loc marker, or null. Persistent, unlike `marker` above it. */
-  locMarker: EqLoc | null
+  /** This zone's TYPED markers (coloured), up to four. Persistent, unlike `marker` above it. */
+  typedMarkers: readonly TypedMarker[]
+  /** This zone's PLAYER marker (light red), scraped from the log, or null. Also persistent. */
+  playerMarker: EqLoc | null
   /** A cross-zone hit was clicked — `useSearchJump`'s handler, which changes zone first. */
   onJump: (to: JumpTarget) => void
 }
 
 export default function MapBody(props: MapBodyProps): JSX.Element {
   const { data, empty, vp, hostRef, layers, bands, floor, pane, zoneName, marker, onJump } = props
-  const { locMarker } = props
+  const { typedMarkers, playerMarker } = props
   return (
     <Stack direction="row" spacing={1.5} sx={{ position: 'relative', flexGrow: 1, minHeight: 0 }}>
       {data != null ? (
@@ -274,7 +284,8 @@ export default function MapBody(props: MapBodyProps): JSX.Element {
           bands={bands}
           floor={floor}
           marker={marker}
-          locMarker={locMarker}
+          typedMarkers={typedMarkers}
+          playerMarker={playerMarker}
           pane={paneOverlay(pane)}
         />
       ) : (

--- a/src/renderer/src/features/maps/MapLocField.tsx
+++ b/src/renderer/src/features/maps/MapLocField.tsx
@@ -1,15 +1,19 @@
-// THE ONE PLACE A POSITION CAN ENTER THIS APP (JOS-98) — type or paste a `/loc`, get a marker.
+// THE PLACE POSITIONS ARE TYPED INTO THIS APP (JOS-98) — paste a `/loc`, get a coloured marker; plus
+// the chips that state every marker a zone holds.
+//
+// UP TO FIVE CHIPS, ONE BOX (JOS-98 wave 4). The box ADDS a typed marker — up to four, each a spot
+// you name (which may not be where you stand), coloured blue → green → yellow → violet as you add
+// them and cycling as you clear and re-add. The RED `player` chip sets itself from the log every
+// time you /loc in game. Each chip centres on its marker on click and removes it on ✕, so a stale
+// dot — of any colour — is never stuck on the map with no way to reach it.
 //
 // WHY A TEXT BOX ON A TOOLBAR THAT "DESCRIBES THE DRAWING". Because this control describes the
-// drawing: it states the one position drawn on the surface, and it is the only way to put one
-// there. The log never says where you are standing, so the alternative to a box is no marker at
-// all — which is what the header used to say, in the flat voice of something that could not be
-// fixed. It can be fixed; the user just has to say the number.
+// drawing: it states the positions drawn on the surface, and the box is the only way to put a typed
+// one there.
 //
-// THE FIELD EMPTIES ON SUCCESS AND THE CHIP TAKES OVER. Two controls, two jobs: the box is where a
-// loc goes IN, the chip is what the app currently BELIEVES — stated in the game's own words and
-// order so it can be checked against the game window without translation. A box that kept the text
-// would be claiming to be both, and a marker you cleared would still be sitting in it.
+// THE FIELD EMPTIES ON SUCCESS AND THE CHIPS TAKE OVER. Two kinds of control, two jobs: the box is
+// where a loc goes IN, the chips are what the app currently BELIEVES — stated in the game's own
+// words and order so they can be checked against the game window without translation.
 //
 // A REFUSAL IS PROSE AND IT STAYS PUT. The message names what the parser choked on and does not
 // vanish on a timer — the user is about to retype something, and an error that disappears while
@@ -31,21 +35,36 @@ import { Chip, IconButton, Stack, TextField, Typography } from '@mui/material'
 import AddLocationAltIcon from '@mui/icons-material/AddLocationAlt'
 import CancelIcon from '@mui/icons-material/Cancel'
 import PlaceIcon from '@mui/icons-material/Place'
+import MyLocationIcon from '@mui/icons-material/MyLocation'
 import type { EqLoc } from './mapGeometry'
-import { formatLoc, parseLoc } from './locMarker'
+import { formatLoc, MARKER_COLOR_HEX, parseLoc, type MarkerColor, type TypedMarker } from './locMarker'
 
 export interface MapLocFieldProps {
-  /** This zone's remembered marker, or null when it has none. */
-  marker: EqLoc | null
-  /** A well-formed reading was entered — place it, and remember it for this zone. */
+  /** This zone's TYPED markers (up to four, coloured), set from the box. */
+  typed: readonly TypedMarker[]
+  /** This zone's PLAYER marker (light red), scraped from the log, or null. */
+  player: EqLoc | null
+  /** A well-formed reading was entered — ADD it as a typed marker for this zone. */
   onPlace: (loc: EqLoc) => void
-  /** Centre the view on the marker that is already placed. */
-  onShow: () => void
-  /** Forget this zone's marker. The only thing that ends one, besides entering another. */
-  onClear: () => void
+  /** Centre the view on the typed marker of this colour. */
+  onShowTyped: (color: MarkerColor) => void
+  /** Forget this zone's typed marker of this colour. */
+  onClearTyped: (color: MarkerColor) => void
+  /** Centre the view on the player marker. */
+  onShowPlayer: () => void
+  /** Forget this zone's player marker (it re-appears the next time you /loc in this zone). */
+  onClearPlayer: () => void
 }
 
-export default function MapLocField({ marker, onPlace, onShow, onClear }: MapLocFieldProps): JSX.Element {
+export default function MapLocField({
+  typed,
+  player,
+  onPlace,
+  onShowTyped,
+  onClearTyped,
+  onShowPlayer,
+  onClearPlayer
+}: MapLocFieldProps): JSX.Element {
   const [text, setText] = useState('')
   const [error, setError] = useState<string | null>(null)
 
@@ -99,25 +118,62 @@ export default function MapLocField({ marker, onPlace, onShow, onClear }: MapLoc
           <AddLocationAltIcon fontSize="small" />
         </IconButton>
       </span>
-      {marker != null && (
+      {/* WHERE YOU ARE, scraped from the log (light red). It has no box — it sets itself when you
+          /loc in game — but it gets the same centre/clear chip so a stale dot is never stuck on the
+          map. `error.light` matches the crosshair's own colour (MapLocMarker). */}
+      {player != null && (
         <Chip
           size="small"
-          color="info"
           variant="outlined"
-          icon={<PlaceIcon />}
-          data-testid="maps-loc-chip"
-          title="The location you entered. Click to centre on it; ✕ to remove it."
-          label={formatLoc(marker)}
-          onClick={onShow}
-          onDelete={onClear}
-          // NAMED, because the chip carries TWO icons and they do OPPOSITE things: the leading
-          // Place icon is part of the click target that centres on the marker, and this one
-          // deletes it. MUI's own class names distinguish them, but a spec that clicks
-          // `[chip] svg` gets the first — which is how the clear affordance was first asserted
-          // green while doing nothing at all.
-          deleteIcon={<CancelIcon data-testid="maps-loc-clear" titleAccess="Remove this marker" />}
+          icon={<MyLocationIcon />}
+          data-testid="maps-loc-chip-player"
+          title="Most recent player /loc, click to center."
+          label={formatLoc(player)}
+          onClick={onShowPlayer}
+          onDelete={onClearPlayer}
+          deleteIcon={<CancelIcon data-testid="maps-loc-clear-player" titleAccess="Remove your position marker" />}
+          sx={{
+            color: 'error.light',
+            borderColor: 'error.light',
+            '& .MuiChip-icon': { color: 'error.light' },
+            '& .MuiChip-deleteIcon': { color: 'error.light' }
+          }}
         />
       )}
+      {/* ONE CHIP PER TYPED MARKER, in the marker's own colour. NEWEST FIRST — the row grows outward
+          from the red player chip on the left, so the freshest mark is always the one next to it and
+          the oldest sits at the far right, which is the one the cycle drops next. `typed` is stored
+          oldest-first, so the display is reversed. All share the `maps-loc-chip` test id (a
+          `data-color` tells them apart) so a count is the number placed. */}
+      {[...typed].reverse().map((m) => {
+        const hex = MARKER_COLOR_HEX[m.color]
+        return (
+          <Chip
+            key={m.color}
+            size="small"
+            variant="outlined"
+            icon={<PlaceIcon />}
+            data-testid="maps-loc-chip"
+            data-color={m.color}
+            title="Manual marker, click to center."
+            label={formatLoc(m.loc)}
+            onClick={() => { onShowTyped(m.color) }}
+            onDelete={() => { onClearTyped(m.color) }}
+            // NAMED, because the chip carries TWO icons and they do OPPOSITE things: the leading
+            // Place icon is part of the click target that centres on the marker, and this one
+            // deletes it. MUI's own class names distinguish them, but a spec that clicks
+            // `[chip] svg` gets the first — which is how the clear affordance was first asserted
+            // green while doing nothing at all.
+            deleteIcon={<CancelIcon data-testid="maps-loc-clear" data-color={m.color} titleAccess="Remove this marker" />}
+            sx={{
+              color: hex,
+              borderColor: hex,
+              '& .MuiChip-icon': { color: hex },
+              '& .MuiChip-deleteIcon': { color: hex }
+            }}
+          />
+        )
+      })}
       {error != null && (
         <Typography variant="caption" color="error" data-testid="maps-loc-error" sx={{ maxWidth: 420 }}>
           {error}

--- a/src/renderer/src/features/maps/MapLocMarker.tsx
+++ b/src/renderer/src/features/maps/MapLocMarker.tsx
@@ -1,28 +1,29 @@
-// THE TYPED-/loc MARKER — one dot, in a colour nothing else on this surface uses (JOS-98).
+// THE /loc CROSSHAIRS — up to TWO dots, each in a colour nothing else on this surface uses (JOS-98).
 //
-// A THIRD AUTHORITY NEEDS A THIRD SYMBOL. The surface already carries two, and a user must never
-// have to ask which source a mark came from:
+// A DISTINCT AUTHORITY NEEDS A DISTINCT SYMBOL. The surface already carries the map file's own
+// labels (round dots in the pack author's category colours — recolouring them destroys meaning) and
+// the app's own finds (spawn pins, the search flash, the selection ring — all the theme's WARNING
+// tone, "the app found this for you"). The crosshairs are neither; they are the positions a /loc
+// stated, so they take a crosshair shape ("this exact point", not "something is around here") and a
+// colour of their own — and there are two of them, from two sources the user must be able to tell
+// apart at a glance (JOS-98 wave 3):
 //
-//   * the MAP FILE's own labels — round dots in the pack author's colours, because those colours
-//     ENCODE a category (zone connection, banker, merchant…) and recolouring them destroys meaning;
-//   * the WIKI's spawn pins, the search-jump flash and the selection ring — all the theme's warning
-//     tone, because they are all "the app found this for you".
+//   * the TYPED readings the user PASTED into the box — up to four, each in one of a fixed cycle of
+//     colours (blue, green, yellow, violet) so several marked spots stay told apart.
+//   * `player` — the reading the LOG scraped, i.e. where the character stood. A light RED, so "where
+//                I am" and "a spot I marked" never read as the same dot.
 //
-// This is neither. It is the one position on the map the USER stated, so it takes the theme's info
-// tone and a crosshair rather than a pin or a ring — a shape that reads as "this exact point"
-// rather than "something is around here". It is also the only mark on the surface that PERSISTS
-// across a restart, which is the other reason it cannot look like the search flash.
+// Both PERSIST across a restart, which is the other reason neither can look like the search flash.
 //
 // INERT, like the label and pin layers: `pointerEvents:'none'` on the frame so drag-to-pan works
-// straight through it, re-enabled on the crosshair itself so its tooltip works. Clearing it is
-// deliberately NOT a click on the map — the toolbar's chip owns that, next to the box the loc was
-// typed into, so the affordance sits where the user's attention already is and a stray click on a
-// map can never delete something they typed.
+// straight through it, re-enabled on the crosshair itself so its tooltip works. Clearing one is
+// deliberately NOT a click on the map — the toolbar's chips own that, next to the box, so a stray
+// click on a map can never delete something the user is relying on.
 
 import type { JSX } from 'react'
 import { useTheme } from '@mui/material'
 import type { EqLoc } from './mapGeometry'
-import { formatLoc } from './locMarker'
+import { formatLoc, MARKER_COLOR_HEX, type MarkerColor } from './locMarker'
 import type { MapViewport } from './useMapViewport'
 
 /** Outer diameter of the ring, CSS pixels. Fixed, like the pins: a mark is not a distance. */
@@ -31,7 +32,12 @@ const RING_PX = 18
 const TICK_PX = 7
 
 export interface MapLocMarkerProps {
-  /** Where the user said they were, in MAP coordinates — already through `mapFromLoc`. */
+  /**
+   * Which crosshair this is: one of the four typed colours, or the scraped `'player'` position. It
+   * decides the colour, the test id, and the tooltip's words.
+   */
+  variant: MarkerColor | 'player'
+  /** Where the reading is, in MAP coordinates — already through `mapFromLoc`. */
   at: { x: number; y: number }
   /** The reading itself, so the tooltip can state it in the game's own words and order. */
   loc: EqLoc
@@ -43,15 +49,24 @@ function tick(color: string, style: React.CSSProperties): JSX.Element {
   return <span style={{ position: 'absolute', background: color, ...style }} />
 }
 
-export function MapLocMarker({ at, loc, vp }: MapLocMarkerProps): JSX.Element {
-  const color = useTheme().palette.info.main
+export function MapLocMarker({ variant, at, loc, vp }: MapLocMarkerProps): JSX.Element {
+  const palette = useTheme().palette
+  const isPlayer = variant === 'player'
+  // A light red for where you are (`error.light`, the theme's light red — legible in both themes),
+  // else the typed colour's fixed hex. Player is one symbol; the typed ones are four of a set.
+  const color = isPlayer ? palette.error.light : MARKER_COLOR_HEX[variant]
+  const testId = isPlayer ? 'maps-loc-marker-player' : 'maps-loc-marker'
+  // The crosshair is inert (centering is the chip's job), so its tooltip only IDENTIFIES the mark —
+  // the "click to center" half lives on the chip, which is the thing you actually click.
+  const title = isPlayer ? 'Most recent player /loc' : 'Manual marker'
   const p = vp.toScreen(at.x, at.y)
   const half = RING_PX / 2
   const arm = { width: 2, height: TICK_PX, marginLeft: -1 } as const
   const bar = { height: 2, width: TICK_PX, marginTop: -1 } as const
   return (
     <div
-      data-testid="maps-loc-marker"
+      data-testid={testId}
+      data-color={variant}
       data-loc={formatLoc(loc)}
       style={{
         position: 'absolute',
@@ -64,7 +79,7 @@ export function MapLocMarker({ at, loc, vp }: MapLocMarkerProps): JSX.Element {
       }}
     >
       <span
-        title={`The location you entered - /loc ${formatLoc(loc)}`}
+        title={title}
         style={{
           position: 'absolute',
           left: -half,

--- a/src/renderer/src/features/maps/MapToolbar.tsx
+++ b/src/renderer/src/features/maps/MapToolbar.tsx
@@ -70,6 +70,7 @@ import ExploreIcon from '@mui/icons-material/Explore'
 import type { MapLayer, MapPackInfo, MapPackPrefs, ZoneShort } from '@shared/maps'
 import { bandLabel, type FloorBand } from './floorSlice'
 import type { EqLoc, LayerMask } from './mapGeometry'
+import type { MarkerColor, TypedMarker } from './locMarker'
 import ZoneSelect from './MapZoneSelect'
 import MapLocField from './MapLocField'
 import type { ZoneMode } from './zoneFollow'
@@ -249,11 +250,14 @@ export interface MapToolbarProps {
   packs: readonly MapPackInfo[]
   prefs: MapPackPrefs
   onPrefs: (prefs: MapPackPrefs) => void
-  /** This zone's typed-/loc marker, or null when it has none (JOS-98). */
-  locMarker: EqLoc | null
+  /** This zone's TYPED markers (up to four, coloured) and PLAYER marker (light red) (JOS-98). */
+  typedMarkers: readonly TypedMarker[]
+  playerMarker: EqLoc | null
   onPlaceLoc: (loc: EqLoc) => void
-  onShowLoc: () => void
-  onClearLoc: () => void
+  onShowTyped: (color: MarkerColor) => void
+  onClearTyped: (color: MarkerColor) => void
+  onShowPlayer: () => void
+  onClearPlayer: () => void
   /** The view is tighter than the whole zone — zoom-out and Fit have something to do. */
   zoomedIn: boolean
   /** > 1 zooms in, < 1 out, around the pane centre. */
@@ -315,7 +319,8 @@ function PackSelect({
 function DrawnControls(props: MapToolbarProps): JSX.Element {
   const { layers, onLayers, bands, floor, onFloor, packs, prefs, onPrefs } = props
   const { zoomedIn, onZoom, onFit } = props
-  const { locMarker, onPlaceLoc, onShowLoc, onClearLoc } = props
+  const { typedMarkers, playerMarker, onPlaceLoc } = props
+  const { onShowTyped, onClearTyped, onShowPlayer, onClearPlayer } = props
   const on = TOGGLEABLE.filter((t) => layers[t.layer]).map((t) => String(t.layer))
   return (
     <>
@@ -385,9 +390,17 @@ function DrawnControls(props: MapToolbarProps): JSX.Element {
         }}
       />
 
-      {/* The one position the app can hold, and the only way one gets in (JOS-98). It belongs on
-          this row for the row's own reason: it describes what is DRAWN on the surface. */}
-      <MapLocField marker={locMarker} onPlace={onPlaceLoc} onShow={onShowLoc} onClear={onClearLoc} />
+      {/* The two positions the app can hold, and the only way one is typed in (JOS-98). It belongs
+          on this row for the row's own reason: it describes what is DRAWN on the surface. */}
+      <MapLocField
+        typed={typedMarkers}
+        player={playerMarker}
+        onPlace={onPlaceLoc}
+        onShowTyped={onShowTyped}
+        onClearTyped={onClearTyped}
+        onShowPlayer={onShowPlayer}
+        onClearPlayer={onClearPlayer}
+      />
     </>
   )
 }

--- a/src/renderer/src/features/maps/MapsView.tsx
+++ b/src/renderer/src/features/maps/MapsView.tsx
@@ -24,14 +24,15 @@
 // own labels, every other installed map AND the bestiary of every other zone (JOS-135) — so a
 // name you half-remember is findable from wherever you happen to be standing.
 //
-// WHAT THIS VIEW CANNOT DO, AND THE HALF OF IT THE USER CAN (JOS-98). There is no AUTOMATIC "you
-// are here" marker and there cannot be: `Your Location` appears ZERO times in the log — re-measured
-// across the owner's whole 116.8 MB of it for this ticket — because /loc answers in the game window
-// and is never written to the file the app tails. What the viewer can do is take the answer from
-// you: the toolbar's `/loc marker` field accepts the line the game printed, drops a crosshair where
-// it says, and keeps it there per zone until you replace it or clear it. The caption states exactly
-// that pair, because a user hunting for a dot that does not exist is a worse outcome than one quiet
-// line saying so (§10) — and a user who does not know they can place one is the report we got.
+// THE "YOU ARE HERE" MARKER, AND THE TWO WAYS IT GETS SET (JOS-98). The log DOES carry your
+// position — `Your Location is …` is written whenever you type `/loc` (wave 1's zero-occurrence
+// sweep was of a character who never ran the command while logging, not a client that withholds
+// it). So the marker moves itself: the character module carries the last live /loc here, and the
+// effect above drops the crosshair on it, silently, for the zone you are standing in. The toolbar's
+// `/loc marker` field stays for the OTHER position — one you paste off a wiki page, or a spot you
+// are not standing on — and the two share one marker per zone, last write winning. What the log
+// still never says is where you are BETWEEN /loc commands: there is no continuous dot that follows
+// you, only the last place you asked about, so the caption promises exactly that and no more.
 //
 // TWO DENSITY CONTROLS LIVE HERE AND BOTH ARE HONEST ABOUT WHAT THEY ARE. Labels declutter
 // themselves (`labelLayout.ts`) — a label that loses its space becomes a dot and hover raises the
@@ -241,9 +242,10 @@ function MapsHeader({
         </Box>
       </Stack>
       <Typography variant="caption" color="text.disabled">
-        The log states the zone you entered and nothing else positional - so there is no automatic
-        “you are here”. Type <code>/loc</code> in game and paste the line into the toolbar to mark
-        where you are; the mark stays with this zone until you replace or clear it.
+        Type <code>/loc</code> in game and the mark moves to where you are - no paste needed. It
+        updates only when you run the command (there is no dot that follows you), and stays with this
+        zone until it changes. You can still paste a <code>/loc</code> line into the toolbar to mark a
+        spot you are not standing on.
       </Typography>
     </Stack>
   )
@@ -361,8 +363,11 @@ function useMapOpenTracking(data: MapData | null): void {
 
 export default function MapsView(): JSX.Element {
   // WHERE YOU ARE. The character module owns the raw display zone off the `zone` log event; it
-  // is undefined until the log prints one, and that absence is a state this view renders.
-  const raw = useModule<CharacterSnap, CharacterDelta>('character', applyCharacterDelta)?.zone
+  // is undefined until the log prints one, and that absence is a state this view renders. It also
+  // carries the last LIVE `/loc` (JOS-98 wave 2) — see the auto-place effect below.
+  const snap = useModule<CharacterSnap, CharacterDelta>('character', applyCharacterDelta)
+  const raw = snap?.zone
+  const liveLoc = snap?.loc
   const { zone, auto, mode, pick, followCurrent } = useZoneSelection(raw)
   const [prefs, setPrefs] = useState<MapPackPrefs>(loadPackPrefs)
   const [layers, setLayers] = useState<LayerMask>(DEFAULT_LAYERS)
@@ -393,6 +398,19 @@ export default function MapsView(): JSX.Element {
   // fetched: a marker attributed to a map that has not loaded would be drawn against the previous
   // zone's bounds for a frame — a dot in the wrong place, which is the one thing this must not do.
   const loc = useLocMarker(data?.zone ?? null, vp)
+  // AUTO-`/loc` (JOS-98 wave 2). When a live /loc arrives, the character module carries it here;
+  // drop the crosshair on it WITHOUT moving the view (owner ruling — a position read from the log
+  // is not a search the user just made). The whole correctness of this is one guard: place it only
+  // when the map on screen IS the zone you are standing in (`data.zone === auto`). Pin another
+  // zone's map and /loc, and the reading is for somewhere the drawn map cannot show — so it waits,
+  // and the module has already cleared it by the time you zone anyway. Keyed to `set`, which is
+  // stable per drawn zone, so this fires on a NEW reading and not on every render.
+  const setPlayerLoc = loc.setPlayer
+  useEffect(() => {
+    if (liveLoc == null) return
+    if (data?.zone == null || data.zone !== auto) return
+    setPlayerLoc(liveLoc)
+  }, [liveLoc, data?.zone, auto, setPlayerLoc])
 
   // THE SIDEBAR. Open by default, remembered in `eq.maps.pane`, closed from its own header. Its
   // filtered rows are derived ONCE and read by both the list and the surface's pins.
@@ -425,10 +443,13 @@ export default function MapsView(): JSX.Element {
           setPrefs(p)
           savePackPrefs(p)
         }}
-        locMarker={loc.marker}
+        typedMarkers={loc.typed}
+        playerMarker={loc.player}
         onPlaceLoc={loc.place}
-        onShowLoc={loc.show}
-        onClearLoc={loc.clear}
+        onShowTyped={loc.showTyped}
+        onClearTyped={loc.clearTyped}
+        onShowPlayer={loc.showPlayer}
+        onClearPlayer={loc.clearPlayer}
         zoomedIn={vp.zoomedIn}
         onZoom={vp.zoomBy}
         onFit={vp.fit}
@@ -448,7 +469,8 @@ export default function MapsView(): JSX.Element {
         pane={pane}
         zoneName={zoneName}
         marker={marker}
-        locMarker={loc.marker}
+        typedMarkers={loc.typed}
+        playerMarker={loc.player}
         onJump={onJump}
       />
       {/* Reserved for the same reason and on the same condition as the toolbar's row (JOS-205). */}

--- a/src/renderer/src/features/maps/locMarker.ts
+++ b/src/renderer/src/features/maps/locMarker.ts
@@ -5,20 +5,20 @@
 // THE ASK (JOS-98, a v0.10.0 report): "Would also be nice if there was a marker on the map for my
 // current positon. I realize I would need to feed the map a /loc but would gladly do so."
 //
-// WHY THE USER HAS TO TYPE IT AT ALL. The log states the zone you entered and nothing else
-// positional — `Your Location` appears ZERO times in it, re-measured for this ticket across the
-// owner's whole 116.8 MB `eqlog_Primitive_freeport.txt` and every other log in that directory,
-// because /loc answers in the game window and is never written to the file the app tails. So there
-// is no live tracking to build and none is pretended: the app knows one position, the one you
-// handed it, and it says so rather than implying a dot that follows you. That absence is also why
-// the reporter offered to feed it in by hand — they had already worked out that nothing else could.
+// WHAT THIS MODULE IS FOR NOW THE LOG IS READ TOO. `/loc` output IS written to the log (see
+// `parseWorld.classifyLoc`, JOS-98 wave 2), and the maps view moves its marker on it automatically —
+// so the common case needs no typing at all. This parser is the OTHER path: a line the user PASTES,
+// which may be a /loc for a spot they are not standing on (a wiki walkthrough's coordinate), or the
+// game's sentence copied by hand. Wave 1's premise that the log never carries the line was measured
+// against a character who simply never ran /loc while logging (`eqlog_Primitive_freeport.txt`); the
+// sibling `eqlog_Arcc_freeport.txt` carries it verbatim.
 //
-// THE SHAPE IS EVIDENCED, NOT INVENTED. Since the log never carries the line, the exact wording was
-// taken from players pasting their own /loc output into wiki walkthroughs (24 pages in
+// THE SHAPE IS EVIDENCED, NOT INVENTED — and it is the SAME shape the log-side classifier reads. The
+// exact wording was taken from players pasting their own /loc into wiki walkthroughs (24 pages in
 // `scripts/sources/cache/quests/`), e.g. page-15280: `Your Location is -192.19, -129.81, 3.26`. So:
 // the literal words `Your Location is`, then three signed decimals at two places, comma-and-space
 // separated, no parentheses, no trailing period of the game's own. Everything this parser accepts
-// BEYOND that shape is defensive slack, never a second believed format.
+// BEYOND that shape is defensive slack for a hand-paste, never a second believed format.
 //
 // THE TRANSFORM IS NOT REDERIVED HERE. `mapGeometry.mapFromLoc` has owned `/loc` → map-file
 // coordinates since wave 1 (`mapX = -ew, mapY = -ns, mapZ = elevation`), it is the transform
@@ -39,8 +39,58 @@
 
 import type { EqLoc } from './mapGeometry'
 
-/** One remembered marker per zone stem, keyed by `ZoneShort`. One marker per zone is the scope. */
-export type LocMarkers = Record<string, EqLoc>
+/**
+ * Up to FIVE markers a zone can carry, from two kinds of authority (JOS-98, waves 3 & 4):
+ *   * `typed`  — `/loc`s the user PASTED into the toolbar box. Up to FOUR, each a spot they may not
+ *                be standing on (a wiki coordinate, a rally point, the four corners of a pull). They
+ *                are theirs to add and clear, and nothing scraped ever overwrites them.
+ *   * `player` — the last `/loc` the LOG scraped, i.e. where the character actually stood (drawn
+ *                light red). Exactly one, and it updates itself as you type /loc in game.
+ * The two kinds are separate on purpose: before this, one overwrote the other.
+ */
+
+/**
+ * The four colours a TYPED marker cycles through, in the order a new one claims them: a new marker
+ * takes the first colour not currently in use, so clearing a marker frees its colour for reuse. At
+ * capacity (all four in use) the OLDEST marker is evicted and its freed colour goes to the new one —
+ * a true cycle (blue → green → yellow → violet → blue …). `player` (light red) is deliberately NOT
+ * in this list; it is a fifth colour nothing typed can take.
+ */
+export const TYPED_COLORS = ['blue', 'green', 'yellow', 'violet'] as const
+export type MarkerColor = (typeof TYPED_COLORS)[number]
+
+/** The most typed markers a zone holds — one per colour (so the max total per zone is this + 1). */
+export const MAX_TYPED = TYPED_COLORS.length
+
+/** The CSS colour each typed colour draws in — a fixed, vivid set that reads on the map paper in
+ *  both themes (the crosshair carries its own dark shadow ring). `player` red lives in the view. */
+export const MARKER_COLOR_HEX: Record<MarkerColor, string> = {
+  blue: '#4c8dff',
+  green: '#3ecf6b',
+  yellow: '#f5c518',
+  violet: '#b06cff'
+}
+
+/** One typed marker: where it is, and which colour identifies it (unique within a zone). */
+export interface TypedMarker {
+  loc: EqLoc
+  color: MarkerColor
+}
+
+/** A zone's markers — up to four typed and one player, or (as an absent key) none. */
+export interface ZoneMarks {
+  typed?: TypedMarker[]
+  player?: EqLoc
+}
+
+/** Every zone's markers, keyed by `ZoneShort`. */
+export type LocMarkers = Record<string, ZoneMarks>
+
+/** The first colour not already used by these markers, in cycle order — null when all four are. */
+function firstUnusedColor(typed: readonly TypedMarker[]): MarkerColor | null {
+  const used = new Set(typed.map((m) => m.color))
+  return TYPED_COLORS.find((c) => !used.has(c)) ?? null
+}
 
 /**
  * Every zone's marker, in ONE key beside `eq.maps.zone` / `eq.maps.packs` / `eq.maps.pane`.
@@ -126,6 +176,57 @@ function readLoc(value: unknown): EqLoc | null {
 }
 
 /**
+ * Read one zone's stored value into `ZoneMarks`, tolerating BOTH shapes:
+ *   * the CURRENT nested form `{ typed?, player? }`, each read through `readLoc`;
+ *   * the LEGACY bare `{ ns, ew, z }` a pre-wave-3 install wrote — that value was always the box's
+ *     marker, so it loads as `typed` and the user's pasted marks survive the upgrade with no re-save.
+ * Returns null when nothing readable is in it, so an empty or corrupt entry drops ALONE (one bad
+ * zone never takes the others with it — same rule as before).
+ */
+function readZoneMarks(value: unknown): ZoneMarks | null {
+  // A LEGACY bare `{ns,ew,z}` — the pre-wave-3 box marker. Loads as one blue typed marker.
+  const bare = readLoc(value)
+  if (bare != null) return { typed: [{ loc: bare, color: TYPED_COLORS[0] }] }
+  if (typeof value !== 'object' || value === null) return null
+  const { typed, player } = value as Record<string, unknown>
+  const t = readTyped(typed)
+  const p = readLoc(player)
+  const out: ZoneMarks = { ...(t.length === 0 ? {} : { typed: t }), ...(p == null ? {} : { player: p }) }
+  return t.length === 0 && p == null ? null : out
+}
+
+/**
+ * Read the typed markers, tolerating every shape this key has ever held: the CURRENT array of
+ * `{loc,color}`, the wave-3 SINGLE `{ns,ew,z}` (one blue marker), and an array of bare readings.
+ * A stored colour is honoured when it is one of the four and not already taken; anything else falls
+ * to the first unused colour. Capped at `MAX_TYPED`, and one unreadable element drops alone.
+ */
+function readTyped(value: unknown): TypedMarker[] {
+  const out: TypedMarker[] = []
+  const push = (loc: EqLoc | null, color: unknown): void => {
+    if (loc == null || out.length >= MAX_TYPED) return
+    const stated = TYPED_COLORS.find((c) => c === color && !out.some((m) => m.color === c))
+    const use = stated ?? firstUnusedColor(out)
+    if (use != null) out.push({ loc, color: use })
+  }
+  if (Array.isArray(value)) {
+    for (const el of value) {
+      const asBare = readLoc(el)
+      if (asBare != null) {
+        push(asBare, undefined)
+      } else if (typeof el === 'object' && el !== null) {
+        const { loc, color } = el as Record<string, unknown>
+        push(readLoc(loc), color)
+      }
+    }
+    return out
+  }
+  // The wave-3 single-typed shape (a bare reading under `typed`): one blue marker.
+  push(readLoc(value), undefined)
+  return out
+}
+
+/**
  * Read the remembered markers.
  *
  * Everything unrecognised folds to `{}` and every unreadable ENTRY is dropped individually, so one
@@ -140,8 +241,9 @@ export function loadLocMarkers(store: LocStore = localStorage): LocMarkers {
     if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) return {}
     const out: LocMarkers = {}
     for (const [zone, value] of Object.entries(parsed as Record<string, unknown>)) {
-      const loc = readLoc(value)
-      if (loc != null && zone !== '') out[zone] = loc
+      if (zone === '') continue
+      const marks = readZoneMarks(value)
+      if (marks != null) out[zone] = marks
     }
     return out
   } catch {
@@ -155,27 +257,69 @@ export function saveLocMarkers(marks: LocMarkers, store: LocStore = localStorage
   return marks
 }
 
+/** Write a zone's markers, dropping the zone key entirely when it would hold nothing. */
+function putZone(marks: LocMarkers, zone: string, next: ZoneMarks): LocMarkers {
+  const out = { ...marks }
+  if ((next.typed == null || next.typed.length === 0) && next.player == null) {
+    // eslint-disable-next-line @typescript-eslint/no-dynamic-delete -- the key IS the zone stem
+    delete out[zone]
+  } else {
+    out[zone] = next
+  }
+  return out
+}
+
 /**
- * Place (or replace) this zone's marker.
+ * ADD a typed marker to this zone, in the first unused colour.
  *
- * Entering a new loc REPLACES the old one rather than adding to it — one marker per zone is the
- * scope, so there is never a list to manage, prune or explain.
+ * Below capacity, the new marker takes `firstUnusedColor`. AT capacity (four already), the OLDEST
+ * marker is evicted so its colour frees, and the new one takes that colour — the cycle the ask
+ * describes. The `player` marker is untouched either way.
  */
-export function setLocMarker(marks: LocMarkers, zone: string, loc: EqLoc): LocMarkers {
-  return { ...marks, [zone]: loc }
+export function addTypedMarker(marks: LocMarkers, zone: string, loc: EqLoc): LocMarkers {
+  const cur = marks[zone]?.typed ?? []
+  // At capacity, drop the oldest so exactly one colour is free; below it, keep them all.
+  const kept = cur.length < MAX_TYPED ? cur : cur.slice(1)
+  const color = firstUnusedColor(kept) ?? TYPED_COLORS[0]
+  return putZone(marks, zone, { ...marks[zone], typed: [...kept, { loc, color }] })
 }
 
-/** Forget this zone's marker, leaving every other zone's alone. */
-export function clearLocMarker(marks: LocMarkers, zone: string): LocMarkers {
-  if (!(zone in marks)) return marks
-  const next = { ...marks }
-  // eslint-disable-next-line @typescript-eslint/no-dynamic-delete -- the key IS the zone stem
-  delete next[zone]
-  return next
+/**
+ * Forget the typed marker of a given COLOUR, leaving the other typed markers, the player marker, and
+ * every other zone alone. When nothing is left in the zone, its key is dropped (no empty shell).
+ */
+export function clearTypedMarker(marks: LocMarkers, zone: string, color: MarkerColor): LocMarkers {
+  const cur = marks[zone]?.typed
+  if (cur == null) return marks
+  const typed = cur.filter((m) => m.color !== color)
+  if (typed.length === cur.length) return marks
+  const nextZone: ZoneMarks = { ...marks[zone] }
+  if (typed.length === 0) delete nextZone.typed
+  else nextZone.typed = typed
+  return putZone(marks, zone, nextZone)
 }
 
-/** This zone's marker, or null. `zone == null` (no map open) is the honest "nothing to draw". */
-export function locMarkerFor(marks: LocMarkers, zone: string | null): EqLoc | null {
+/** Set (replace) this zone's single PLAYER marker, leaving every typed marker alone. */
+export function setPlayerMarker(marks: LocMarkers, zone: string, loc: EqLoc): LocMarkers {
+  return putZone(marks, zone, { ...marks[zone], player: loc })
+}
+
+/** Forget this zone's player marker, leaving the typed markers alone. */
+export function clearPlayerMarker(marks: LocMarkers, zone: string): LocMarkers {
+  if (marks[zone]?.player == null) return marks
+  const nextZone: ZoneMarks = { ...marks[zone] }
+  delete nextZone.player
+  return putZone(marks, zone, nextZone)
+}
+
+/** This zone's typed markers, in the order they were added. `zone == null` ⇒ none. */
+export function typedMarkersFor(marks: LocMarkers, zone: string | null): TypedMarker[] {
+  if (zone == null) return []
+  return marks[zone]?.typed ?? []
+}
+
+/** This zone's player marker, or null. `zone == null` (no map open) is the honest "nothing". */
+export function playerMarkerFor(marks: LocMarkers, zone: string | null): EqLoc | null {
   if (zone == null) return null
-  return marks[zone] ?? null
+  return marks[zone]?.player ?? null
 }

--- a/src/renderer/src/features/maps/useLocMarker.ts
+++ b/src/renderer/src/features/maps/useLocMarker.ts
@@ -10,7 +10,7 @@
 // KEYED BY ZONE, READ BY ZONE. The whole map of markers is held in state and the CURRENT zone's is
 // derived, rather than loading one zone's marker on every zone change. That is what makes walking
 // out of a zone and back — or pinning another map and returning — free of a reload, and it is why
-// clearing one zone's marker provably cannot touch another's (`clearLocMarker`).
+// clearing one zone's marker provably cannot touch another's (`clearTypedMarker`).
 //
 // PLACING JUMPS, RESTORING DOES NOT. Typing a loc is a question ("where is that?") and the answer
 // is useless off screen, so a placement centres the view on it at the search's own zoom. A marker
@@ -22,25 +22,42 @@ import type { ZoneShort } from '@shared/maps'
 import { JUMP_ZOOM } from './MapBody'
 import { mapFromLoc, type EqLoc } from './mapGeometry'
 import {
-  clearLocMarker,
+  addTypedMarker,
+  clearPlayerMarker,
+  clearTypedMarker,
   loadLocMarkers,
-  locMarkerFor,
+  playerMarkerFor,
   saveLocMarkers,
-  setLocMarker,
-  type LocMarkers
+  setPlayerMarker,
+  typedMarkersFor,
+  type LocMarkers,
+  type MarkerColor,
+  type TypedMarker
 } from './locMarker'
 import type { MapViewport } from './useMapViewport'
 
-/** What the toolbar needs to state the marker, and what the surface needs to draw it. */
+/** What the toolbar needs to state the markers, and what the surface needs to draw them. */
 export interface LocMarkerState {
-  /** This zone's marker in the game's own axes, or null. */
-  marker: EqLoc | null
-  /** A well-formed reading was entered: remember it for this zone, and go look at it. */
+  /** This zone's TYPED markers (up to four, each a distinct colour), oldest first. */
+  typed: TypedMarker[]
+  /** This zone's PLAYER marker (scraped from the log, drawn light red), or null. */
+  player: EqLoc | null
+  /** A well-formed reading was entered in the box: ADD it as a typed marker, and go look at it. */
   place: (loc: EqLoc) => void
-  /** Centre on the marker already placed. The chip's click. */
-  show: () => void
-  /** Forget this zone's marker. */
-  clear: () => void
+  /**
+   * Update the PLAYER marker WITHOUT moving the view — the auto-`/loc` path (JOS-98 wave 2). A
+   * position read from the log is not a question the user just asked on the map (that is `place`,
+   * the typed field), so it moves the crosshair and leaves the viewport exactly where it was.
+   */
+  setPlayer: (loc: EqLoc) => void
+  /** Centre on the typed marker of this colour. A blue/green/yellow/violet chip's click. */
+  showTyped: (color: MarkerColor) => void
+  /** Centre on the player marker. The red chip's click. */
+  showPlayer: () => void
+  /** Forget this zone's typed marker of this colour. */
+  clearTyped: (color: MarkerColor) => void
+  /** Forget this zone's player marker. */
+  clearPlayer: () => void
 }
 
 export function useLocMarker(zone: ZoneShort | null, vp: MapViewport): LocMarkerState {
@@ -49,7 +66,8 @@ export function useLocMarker(zone: ZoneShort | null, vp: MapViewport): LocMarker
     saveLocMarkers(marks)
   }, [marks])
 
-  const marker = locMarkerFor(marks, zone)
+  const typed = typedMarkersFor(marks, zone)
+  const player = playerMarkerFor(marks, zone)
   const { centerOn, zoomedIn, view } = vp
 
   // Fitted ⇒ a marker is a few pixels from everything else, so the jump also zooms in; already
@@ -67,20 +85,44 @@ export function useLocMarker(zone: ZoneShort | null, vp: MapViewport): LocMarker
       // No map open ⇒ nowhere to remember it. The field is gated on `hasMap`, so this is a guard,
       // not a path: a marker filed under no zone could never be found again.
       if (zone == null) return
-      setMarks((prev) => setLocMarker(prev, zone, loc))
+      setMarks((prev) => addTypedMarker(prev, zone, loc))
       goTo(loc)
     },
     [zone, goTo]
   )
 
-  const show = useCallback(() => {
-    if (marker != null) goTo(marker)
-  }, [marker, goTo])
+  // The auto path: remember the PLAYER position for this zone, do NOT move the view (owner ruling,
+  // JOS-98 wave 2). Same guard as `place` — no map open, nowhere to file it.
+  const setPlayer = useCallback(
+    (loc: EqLoc) => {
+      if (zone == null) return
+      setMarks((prev) => setPlayerMarker(prev, zone, loc))
+    },
+    [zone]
+  )
 
-  const clear = useCallback(() => {
+  const showTyped = useCallback(
+    (color: MarkerColor) => {
+      const m = typed.find((t) => t.color === color)
+      if (m != null) goTo(m.loc)
+    },
+    [typed, goTo]
+  )
+  const showPlayer = useCallback(() => {
+    if (player != null) goTo(player)
+  }, [player, goTo])
+
+  const clearTyped = useCallback(
+    (color: MarkerColor) => {
+      if (zone == null) return
+      setMarks((prev) => clearTypedMarker(prev, zone, color))
+    },
+    [zone]
+  )
+  const clearPlayer = useCallback(() => {
     if (zone == null) return
-    setMarks((prev) => clearLocMarker(prev, zone))
+    setMarks((prev) => clearPlayerMarker(prev, zone))
   }, [zone])
 
-  return { marker, place, show, clear }
+  return { typed, player, place, setPlayer, showTyped, showPlayer, clearTyped, clearPlayer }
 }

--- a/src/shared/characterTypes.ts
+++ b/src/shared/characterTypes.ts
@@ -12,6 +12,7 @@
 
 import type { CharacterRef } from './types'
 import type { LevelStatement } from './currentLevel'
+import type { LocReading } from './logEvents'
 
 /** character module: current character, zone, and the level the log last STATED. */
 export interface CharacterSnap {
@@ -27,6 +28,18 @@ export interface CharacterSnap {
    * projection). See shared/currentLevel.ts for the precedence rules and the wording.
    */
   level?: LevelStatement
+  /**
+   * THE LAST `/loc` YOU TYPED (JOS-98 wave 2) — north/south, west/east, elevation, as the game
+   * printed it. The maps view reads this to move its marker automatically: type /loc in game and
+   * the crosshair follows, no paste.
+   *
+   * TRANSIENT AND LIVE-ONLY, unlike `zone`/`level`. It is set only from a LIVE `loc` event and is
+   * CLEARED the instant you zone (a reading for the zone you just left must never land on the map
+   * you just entered). So the historical replay never resurrects a stale position on launch, and a
+   * `loc: undefined` in a delta means "nothing to place", not "erase the marker" — the marker's own
+   * per-zone persistence is the renderer's, in localStorage.
+   */
+  loc?: LocReading
 }
 
 /** Every field is optional in a delta — the module pushes only what actually moved. */

--- a/src/shared/logEvents.ts
+++ b/src/shared/logEvents.ts
@@ -59,6 +59,39 @@ export interface ZoneEvent extends LogEventBase {
 }
 
 /**
+ * A `/loc` reading as the game printed it: north/south, west/east, elevation — the same three
+ * numbers, in the same order, that `EqLoc` (renderer/features/maps/mapGeometry.ts) holds still.
+ * Serializable and behaviour-free, so it crosses the main↔web boundary as plain data.
+ */
+export interface LocReading {
+  /** first number /loc prints — north/south. */
+  ns: number
+  /** second number /loc prints — west/east. */
+  ew: number
+  /** third number /loc prints — elevation. */
+  z: number
+}
+
+/**
+ * `Your Location is 1467.76, 1141.96, 164.72` — the answer to `/loc`, and the ONLY positional line
+ * the game writes to the log. It is written just when you TYPE the command (there is no continuous
+ * position stream), so this event is how the map's marker moves itself: type /loc, the crosshair
+ * follows, no copy-paste.
+ *
+ * WHY THE APP LONG BELIEVED THIS LINE DID NOT EXIST. The first measurement (JOS-98) swept the
+ * owner's `eqlog_Primitive_freeport.txt` and found `Your Location` ZERO times — but that was a
+ * character who simply never ran /loc while logging, not a client that withholds the line. The
+ * sibling `eqlog_Arcc_freeport.txt` carries it verbatim, in exactly this shape.
+ *
+ * ORDER IS THE TRAP (mapGeometry.ts, JOS-65): the first number is north/south, NOT an x. `loc` names
+ * its fields `ns`/`ew` for that reason and nothing downstream calls them x and y.
+ */
+export interface LocEvent extends LogEventBase {
+  kind: 'loc'
+  loc: LocReading
+}
+
+/**
  * Where a looted-and-routed item went (Tasks #40/#47). The held-vs-gone rule lives in
  * ONE place — `computeHeldCounts` (renderer, features/posky/heldCounts.ts):
  *   'currency' — stored in the currency tab (kept, quest-countable — e.g. Wind Runes)
@@ -1425,6 +1458,12 @@ export interface UnknownEvent extends LogEventBase {
 /** The canonical discriminated union of everything the parser can emit. */
 export type LogEvent =
   | ZoneEvent
+  // The ONE positional line the log carries — `Your Location is …`, written when you type /loc
+  // (JOS-98 wave 2). Beside `zone` because it is the same subject one notch finer: zone says which
+  // map, this says where on it. Deliberately NOT in `alertTypes.ts`'s curated `LogEventKind` — like
+  // `ccWake` it is internal plumbing (the maps marker reads it through the character module), not a
+  // trigger a user composes an alert from.
+  | LocEvent
   | LootEventE
   // The three acquisition families that carry no corpse (JOS-144, ./acquireEvents). They sit
   // beside loot because they answer the same question — how did this reach me — and every line

--- a/tests/e2e/maps-loc.e2e.mts
+++ b/tests/e2e/maps-loc.e2e.mts
@@ -95,10 +95,18 @@ function zoneOf(page: Page): Promise<string> {
   )
 }
 
-/** The reading the drawn crosshair was placed from, or `null` when nothing is drawn. */
+/** The reading the FIRST drawn crosshair was placed from, or `null` when nothing is drawn. */
 function markerLocOf(page: Page): Promise<string | null> {
   return page.evaluate(
     (sel) => document.querySelector(sel)?.getAttribute('data-loc') ?? null,
+    LOC_MARKER
+  )
+}
+
+/** Every typed crosshair's reading, in DOM (add) order — the subject of the multi-marker steps. */
+function markerLocsOf(page: Page): Promise<string[]> {
+  return page.evaluate(
+    (sel) => [...document.querySelectorAll(sel)].map((el) => el.getAttribute('data-loc') ?? ''),
     LOC_MARKER
   )
 }
@@ -302,25 +310,44 @@ async function stepSurvivesTabs(page: Page): Promise<void> {
   check('…and the toolbar still states it', (await chipTextOf(page)) !== '')
 }
 
-/** 6. ENTERING ANOTHER LOC REPLACES IT — one marker per zone, never a list. */
-async function stepReplace(page: Page, anchor: Anchor): Promise<void> {
-  const before = await markerLocOf(page)
-  // A point 40 units north-east of the anchor: a real, different position on the same map.
-  await typeLoc(page, `${String(-anchor.y + 40)}, ${String(-anchor.x - 40)}, ${String(anchor.z)}`)
-  const after = await settle(() => markerLocOf(page), (l) => l !== before, { timeoutMs: 10_000 })
-  check('entering another /loc REPLACES the marker', after !== before, `${String(before)} → ${String(after)}`)
-  check('…and there is still exactly one', (await countOf(page, LOC_MARKER)) === 1)
-  const stored = await storedOf(page)
-  check('…with one entry stored for this zone, not two', (stored?.match(/"ns"/g) ?? []).length === 1, String(stored))
+/** 6. ENTERING MORE LOCS ADDS MARKERS — up to four, then the colour cycle evicts the oldest. */
+async function stepAddMore(page: Page, anchor: Anchor): Promise<void> {
+  const start = await markerLocsOf(page)
+  check('one marker is on the map to begin with', start.length === 1, String(start.length))
+  // Three more real, distinct positions on the same map — four markers, four colours.
+  for (const [dy, dx] of [[40, -40], [-60, 60], [90, 80]] as const) {
+    await typeLoc(page, `${String(-anchor.y + dy)}, ${String(-anchor.x + dx)}, ${String(anchor.z)}`)
+  }
+  const four = await settle(() => countOf(page, LOC_MARKER), (c) => c === 4, { timeoutMs: 12_000 })
+  check('typing more /locs ADDS markers rather than replacing', four === 4, String(four))
+  check('…and each is stated by its own chip', (await countOf(page, LOC_CHIP)) === 4)
+  const stored4 = await storedOf(page)
+  check('…stored as four coloured entries for this zone', (stored4?.match(/"color"/g) ?? []).length === 4, String(stored4))
+
+  // A FIFTH add cannot make a fifth marker: the oldest is evicted, its colour cycles to the new one.
+  const oldest = (await markerLocsOf(page))[0]
+  await typeLoc(page, `${String(-anchor.y + 200)}, ${String(-anchor.x + 10)}, ${String(anchor.z)}`)
+  const after = await settle(
+    () => markerLocsOf(page),
+    (ls) => ls.length === 4 && !ls.includes(oldest),
+    { timeoutMs: 12_000 }
+  )
+  check('a fifth /loc never makes a fifth marker — the cap holds at four', after.length === 4, String(after.length))
+  check('…and it evicts the OLDEST, cycling the colour', !after.includes(oldest), `${oldest} should be gone`)
 }
 
-/** 7. CLEARING REMOVES IT — from the map, from the toolbar and from the store. */
+/** 7. CLEARING REMOVES THEM — every marker, from the map, the toolbar and the store. */
 async function stepClear(page: Page, zone: string): Promise<void> {
-  await page.click(LOC_CLEAR, { timeout: 15_000 })
-  check('clearing the chip removes the marker from the map', await settleGone(page, LOC_MARKER, { timeoutMs: 8000 }))
-  check('…and the chip with it', (await countOf(page, LOC_CHIP)) === 0)
+  // Several markers are down; clear each in turn (the ✕ always removes the first chip).
+  for (let guard = 8; guard > 0 && (await countOf(page, LOC_MARKER)) > 0; guard--) {
+    const n = await countOf(page, LOC_MARKER)
+    await page.click(LOC_CLEAR, { timeout: 15_000 })
+    await settle(() => countOf(page, LOC_MARKER), (c) => c < n, { timeoutMs: 8000 })
+  }
+  check('clearing the chips removes every marker from the map', await settleGone(page, LOC_MARKER, { timeoutMs: 8000 }))
+  check('…and the chips with them', (await countOf(page, LOC_CHIP)) === 0)
   const stored = await settle(() => storedOf(page), (s) => s == null || !s.includes(`"${zone}"`), { timeoutMs: 8000 })
-  check('…and it is gone from the store, not merely off the screen', stored == null || !stored.includes(`"${zone}"`), String(stored))
+  check('…and they are gone from the store, not merely off the screen', stored == null || !stored.includes(`"${zone}"`), String(stored))
 }
 
 /** Everything launch 1 asserts. Returns the reading left placed for launch 2, or null when skipped. */
@@ -343,7 +370,7 @@ async function firstLaunch(page: Page): Promise<{ zone: string; loc: string } | 
   await stepLandmark(page, anchor)
   await stepStated(page, zone, anchor)
   await stepSurvivesTabs(page)
-  await stepReplace(page, anchor)
+  await stepAddMore(page, anchor)
   await stepClear(page, zone)
 
   // Arm the restart: place one last marker and hand its reading to launch 2.
@@ -394,7 +421,7 @@ async function main(): Promise<void> {
   const userData = makeUserData()
   const log = stageFixture('e2e-maps.log', { maps: true })
   try {
-    console.log('launch 1: refuse a bad loc, place a good one on a landmark, tab round trip, replace, clear…')
+    console.log('launch 1: refuse a bad loc, place one on a landmark, tab round trip, add up to four + cycle, clear…')
     const first = await launchOnFixture(log, { userData })
     let placed: { zone: string; loc: string } | null = null
     try {

--- a/tests/mapLocLive.test.mts
+++ b/tests/mapLocLive.test.mts
@@ -1,0 +1,114 @@
+// AUTO-`/loc` (JOS-98 wave 2) — the log DOES carry your position, and the marker moves itself.
+//
+// Wave 1's whole premise was that `Your Location is …` is never written to the log; that was a
+// measurement of a character who never ran /loc while logging, not a client limitation. The sibling
+// `eqlog_Arcc_freeport.txt` carries the line verbatim:
+//
+//   [Thu Aug 20 02:02:10 2026] Your Location is 1467.76, 1141.96, 164.72
+//
+// So this suite pins the two halves that make the marker follow you: the PARSER claims the line as a
+// `loc` event (and refuses to claim a chat line quoting it), and the CHARACTER MODULE carries the
+// last LIVE reading — cleared the instant you zone, and never set from the historical replay.
+//
+// Pure node: the real parser, the real module, no Electron and no DOM — so it never skips. The
+// renderer half (silent placement, the drawn-zone guard) is the map-loc e2e's job.
+
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { parseEvent } from '../src/main/log/parser'
+import { CharacterModule } from '../src/main/modules/character'
+import type { LogEvent, LocEvent } from '../src/shared/logEvents'
+
+/** A real log line with the game's bracketed stamp, as the tailer hands it over. */
+const LINE = '[Thu Aug 20 02:02:10 2026] Your Location is 1467.76, 1141.96, 164.72'
+
+// ---- the parser claims the line, in the game's own order ----------------------------------
+
+test('parseEvent reads a /loc line into a loc event — NORTH/SOUTH first, then west/east', () => {
+  const ev = parseEvent(LINE, 7)
+  assert.ok(ev, 'the line parses')
+  assert.equal(ev.kind, 'loc')
+  const loc = (ev as LocEvent).loc
+  assert.deepEqual(loc, { ns: 1467.76, ew: 1141.96, z: 164.72 })
+  // seq is stamped by the feeder, ts off the bracket.
+  assert.equal(ev.seq, 7)
+})
+
+test('parseEvent takes the negative and no-decimal shapes the game prints', () => {
+  const neg = parseEvent('[Thu Aug 20 02:02:29 2026] Your Location is 1151.08, -2382.86, 280.01', 0)
+  assert.deepEqual((neg as LocEvent).loc, { ns: 1151.08, ew: -2382.86, z: 280.01 })
+  const whole = parseEvent('[Thu Aug 20 02:02:29 2026] Your Location is 155, -411, 15', 0)
+  assert.deepEqual((whole as LocEvent).loc, { ns: 155, ew: -411, z: 15 })
+})
+
+test('a chat line QUOTING the sentence is not a loc — the stamp is stripped, the name is not', () => {
+  // The classifier sees the message with `[timestamp] ` gone; a say/tell begins with the speaker's
+  // name, so it can never look like the anchored `Your Location is …`.
+  const chat = parseEvent(`[Thu Aug 20 02:02:29 2026] Bob says, 'Your Location is 1, 2, 3'`, 0)
+  assert.notEqual(chat?.kind, 'loc')
+  // Prose after the numbers is refused too — three numbers is the whole shape, not a prefix of one.
+  const trailing = parseEvent('[Thu Aug 20 02:02:29 2026] Your Location is 1, 2, 3 near the ruins', 0)
+  assert.notEqual(trailing?.kind, 'loc')
+})
+
+// ---- the character module carries the last LIVE reading -------------------------------------
+
+const loc = (ns: number, ew: number, z: number, seq: number): LogEvent =>
+  ({ kind: 'loc', seq, ts: seq * 1000, raw: '', loc: { ns, ew, z } })
+const zone = (name: string, seq: number): LogEvent =>
+  ({ kind: 'zone', seq, ts: seq * 1000, raw: '', zone: name })
+
+test('a LIVE /loc lands in the snapshot and is pushed as a delta', () => {
+  const mod = new CharacterModule()
+  mod.reset()
+  mod.onEvent(zone('East Freeport', 1), true)
+  mod.flushDelta()
+  mod.onEvent(loc(1467.76, 1141.96, 164.72, 2), true)
+  const d = mod.flushDelta()
+  assert.ok(d, 'the reading is news')
+  assert.deepEqual(d.delta.loc, { ns: 1467.76, ew: 1141.96, z: 164.72 })
+  assert.deepEqual(mod.snapshot().state.loc, { ns: 1467.76, ew: 1141.96, z: 164.72 })
+})
+
+test('a REPLAYED /loc (live:false) is ignored — a days-old reading must not place a marker on launch', () => {
+  const mod = new CharacterModule()
+  mod.reset()
+  mod.onEvent(zone('East Freeport', 1)) // replay: live defaults false
+  mod.onEvent(loc(1, 2, 3, 2)) // replay
+  // The zone still folds (modules accumulate during replay — the registry gates the PUSH, not the
+  // fold). What must NOT fold from history is the position: the marker is a live-only effect.
+  assert.equal(mod.snapshot().state.loc, undefined, 'no loc folded from history')
+  const d = mod.flushDelta()
+  assert.equal(d?.delta.loc, undefined, 'and no loc reaches a delta')
+  assert.ok(d == null || !('loc' in d.delta), 'the loc key never appears from a replayed reading')
+})
+
+test('zoning RETIRES the reading — the loc you took in one zone cannot land on the next', () => {
+  const mod = new CharacterModule()
+  mod.reset()
+  mod.onEvent(zone('East Freeport', 1), true)
+  mod.onEvent(loc(613, 51, 0, 2), true)
+  mod.flushDelta()
+  mod.onEvent(zone('West Commonlands', 3), true)
+  const d = mod.flushDelta()
+  assert.ok(d, 'the zone change is a delta')
+  assert.equal(d.delta.zone, 'West Commonlands')
+  // The clear is `loc: undefined` in the delta — "nothing to place now", not "erase the marker".
+  assert.ok('loc' in d.delta, 'the delta explicitly clears the transient loc')
+  assert.equal(d.delta.loc, undefined)
+  assert.equal(mod.snapshot().state.loc, undefined)
+})
+
+test('reset and epoch both drop the reading', () => {
+  const mod = new CharacterModule()
+  mod.reset()
+  mod.onEvent(zone('East Freeport', 1), true)
+  mod.onEvent(loc(1, 2, 3, 2), true)
+  mod.onEvent({ kind: 'epoch', seq: 3, ts: 3000, raw: '', reason: 'launch' }, true)
+  assert.equal(mod.snapshot().state.loc, undefined, 'epoch (rebirth) clears it')
+
+  mod.onEvent(loc(4, 5, 6, 4), true)
+  assert.deepEqual(mod.snapshot().state.loc, { ns: 4, ew: 5, z: 6 })
+  mod.reset()
+  assert.equal(mod.snapshot().state.loc, undefined, 'reset clears it')
+})

--- a/tests/mapLocMarker.test.mts
+++ b/tests/mapLocMarker.test.mts
@@ -35,13 +35,18 @@ import { test } from 'node:test'
 import assert from 'node:assert/strict'
 import {
   LOC_MARKERS_KEY,
-  clearLocMarker,
+  MAX_TYPED,
+  TYPED_COLORS,
+  addTypedMarker,
+  clearPlayerMarker,
+  clearTypedMarker,
   formatLoc,
   loadLocMarkers,
-  locMarkerFor,
   parseLoc,
+  playerMarkerFor,
   saveLocMarkers,
-  setLocMarker,
+  setPlayerMarker,
+  typedMarkersFor,
   type LocStore
 } from '../src/renderer/src/features/maps/locMarker'
 import { fit, mapFromLoc, project } from '../src/renderer/src/features/maps/mapGeometry'
@@ -254,56 +259,132 @@ test('what the chip states round-trips back through the parser', () => {
   assert.deepEqual(loc(formatLoc(there)), there)
 })
 
-// ---- 6. sticking around ---------------------------------------------------------------------
+// ---- 6. sticking around, and the colour cycle (JOS-98 wave 4) --------------------------------
 
-test('a marker is remembered PER ZONE, and one zone’s marker is not another’s', () => {
+/** The colours of a zone's typed markers, in add order — the whole subject of the cycle tests. */
+function colorsOf(marks: ReturnType<typeof addTypedMarker>, zone: string): string[] {
+  return typedMarkersFor(marks, zone).map((m) => m.color)
+}
+
+test('a marker is remembered PER ZONE, and one zone’s markers are not another’s', () => {
   const store = fakeStore()
-  let marks = setLocMarker({}, 'oasis', { ns: 613, ew: 51, z: 0 })
-  marks = setLocMarker(marks, 'northkarana', { ns: -1, ew: -2, z: -3 })
+  let marks = addTypedMarker({}, 'oasis', { ns: 613, ew: 51, z: 0 })
+  marks = addTypedMarker(marks, 'northkarana', { ns: -1, ew: -2, z: -3 })
   saveLocMarkers(marks, store)
 
   const back = loadLocMarkers(store)
   assert.deepEqual(back, marks, 'the whole set crosses the store intact')
-  assert.deepEqual(locMarkerFor(back, 'oasis'), { ns: 613, ew: 51, z: 0 })
-  assert.deepEqual(locMarkerFor(back, 'northkarana'), { ns: -1, ew: -2, z: -3 })
-  // A zone with no marker, and the no-map-open case, are both the honest null.
-  assert.equal(locMarkerFor(back, 'freporte'), null)
-  assert.equal(locMarkerFor(back, null), null)
+  assert.deepEqual(typedMarkersFor(back, 'oasis'), [{ loc: { ns: 613, ew: 51, z: 0 }, color: 'blue' }])
+  assert.deepEqual(typedMarkersFor(back, 'northkarana'), [{ loc: { ns: -1, ew: -2, z: -3 }, color: 'blue' }])
+  // A zone with no marker, and the no-map-open case, are both the honest empty.
+  assert.deepEqual(typedMarkersFor(back, 'freporte'), [])
+  assert.deepEqual(typedMarkersFor(back, null), [])
 })
 
-test('entering a new loc REPLACES this zone’s marker — one marker per zone is the scope', () => {
-  const first = setLocMarker({}, 'oasis', { ns: 1, ew: 2, z: 3 })
-  const second = setLocMarker(first, 'oasis', { ns: 4, ew: 5, z: 6 })
-  assert.deepEqual(second, { oasis: { ns: 4, ew: 5, z: 6 } })
-  assert.equal(Object.keys(second).length, 1, 'never a list to manage')
+test('typed markers and the player marker are INDEPENDENT — one never disturbs the other', () => {
+  let marks = addTypedMarker({}, 'oasis', { ns: 1, ew: 2, z: 3 })
+  marks = setPlayerMarker(marks, 'oasis', { ns: 4, ew: 5, z: 6 })
+  assert.deepEqual(playerMarkerFor(marks, 'oasis'), { ns: 4, ew: 5, z: 6 })
+  assert.deepEqual(colorsOf(marks, 'oasis'), ['blue'], 'the player set did not touch the typed list')
+  // Adding more typed markers leaves the scraped one where it was.
+  marks = addTypedMarker(marks, 'oasis', { ns: 7, ew: 8, z: 9 })
+  assert.deepEqual(playerMarkerFor(marks, 'oasis'), { ns: 4, ew: 5, z: 6 })
+  // …and re-scraping leaves the typed list untouched.
+  marks = setPlayerMarker(marks, 'oasis', { ns: 10, ew: 11, z: 12 })
+  assert.deepEqual(colorsOf(marks, 'oasis'), ['blue', 'green'])
 })
 
-test('clearing removes THIS zone’s marker and leaves every other zone alone', () => {
-  let marks = setLocMarker({}, 'oasis', { ns: 1, ew: 2, z: 3 })
-  marks = setLocMarker(marks, 'gfaydark', { ns: 4, ew: 5, z: 6 })
-  const cleared = clearLocMarker(marks, 'oasis')
-  assert.equal(locMarkerFor(cleared, 'oasis'), null)
-  assert.deepEqual(locMarkerFor(cleared, 'gfaydark'), { ns: 4, ew: 5, z: 6 })
-  // Clearing a zone that has none is a no-op that does not churn the object.
-  assert.equal(clearLocMarker(cleared, 'oasis'), cleared)
-  // …and the removal survives the store, rather than being resurrected by a stale write.
+test('adding markers claims colours in cycle order — blue, green, yellow, violet', () => {
+  let marks: ReturnType<typeof addTypedMarker> = {}
+  for (let i = 0; i < MAX_TYPED; i++) marks = addTypedMarker(marks, 'oasis', { ns: i, ew: 0, z: 0 })
+  assert.deepEqual(colorsOf(marks, 'oasis'), [...TYPED_COLORS])
+  assert.equal(typedMarkersFor(marks, 'oasis').length, MAX_TYPED, 'four markers, one per colour')
+})
+
+test('clearing a colour frees it, and the next add takes the FIRST unused colour', () => {
+  let marks: ReturnType<typeof addTypedMarker> = {}
+  for (let i = 0; i < MAX_TYPED; i++) marks = addTypedMarker(marks, 'oasis', { ns: i, ew: 0, z: 0 })
+  // Free green (the 2nd). The next add fills the hole rather than appending a 5th of a new colour.
+  marks = clearTypedMarker(marks, 'oasis', 'green')
+  assert.deepEqual(colorsOf(marks, 'oasis'), ['blue', 'yellow', 'violet'])
+  marks = addTypedMarker(marks, 'oasis', { ns: 99, ew: 0, z: 0 })
+  assert.deepEqual(colorsOf(marks, 'oasis'), ['blue', 'yellow', 'violet', 'green'], 'green reused')
+})
+
+test('AT CAPACITY the oldest marker is evicted and its colour cycles to the new one', () => {
+  let marks: ReturnType<typeof addTypedMarker> = {}
+  for (let i = 0; i < MAX_TYPED; i++) marks = addTypedMarker(marks, 'oasis', { ns: i, ew: 0, z: 0 })
+  // The oldest is blue at ns 0. A fifth add drops it, reuses blue, and stays at four total.
+  marks = addTypedMarker(marks, 'oasis', { ns: 500, ew: 0, z: 0 })
+  const after = typedMarkersFor(marks, 'oasis')
+  assert.equal(after.length, MAX_TYPED, 'never more than four typed markers')
+  assert.deepEqual(after.map((m) => m.color), ['green', 'yellow', 'violet', 'blue'], 'blue cycled to the newest')
+  assert.deepEqual(after[after.length - 1], { loc: { ns: 500, ew: 0, z: 0 }, color: 'blue' })
+  assert.ok(!after.some((m) => m.loc.ns === 0), 'the evicted oldest is gone')
+})
+
+test('clearing one typed colour leaves the others and the player, and clearing all drops the zone', () => {
+  let marks = addTypedMarker({}, 'oasis', { ns: 1, ew: 2, z: 3 }) // blue
+  marks = addTypedMarker(marks, 'oasis', { ns: 4, ew: 5, z: 6 }) // green
+  marks = setPlayerMarker(marks, 'oasis', { ns: 7, ew: 8, z: 9 })
+  const noBlue = clearTypedMarker(marks, 'oasis', 'blue')
+  assert.deepEqual(colorsOf(noBlue, 'oasis'), ['green'], 'only blue went')
+  assert.deepEqual(playerMarkerFor(noBlue, 'oasis'), { ns: 7, ew: 8, z: 9 }, 'the player marker is untouched')
+  // Clearing a colour the zone does not have is a no-op that does not churn the object.
+  assert.equal(clearTypedMarker(noBlue, 'oasis', 'violet'), noBlue)
+  // Clear the last typed AND the player ⇒ the zone key is dropped entirely (no empty shell).
+  const noTyped = clearTypedMarker(noBlue, 'oasis', 'green')
+  assert.deepEqual(noTyped, { oasis: { player: { ns: 7, ew: 8, z: 9 } } }, 'the player alone keeps the zone')
+  const empty = clearPlayerMarker(noTyped, 'oasis')
+  assert.deepEqual(empty, {})
+  assert.ok(!('oasis' in empty), 'the zone key is dropped when nothing remains')
+})
+
+test('clearing survives the store and leaves every other zone alone', () => {
+  let marks = addTypedMarker({}, 'oasis', { ns: 1, ew: 2, z: 3 })
+  marks = addTypedMarker(marks, 'gfaydark', { ns: 4, ew: 5, z: 6 })
+  const cleared = clearTypedMarker(marks, 'oasis', 'blue')
+  assert.deepEqual(typedMarkersFor(cleared, 'oasis'), [])
+  assert.deepEqual(colorsOf(cleared, 'gfaydark'), ['blue'])
   const store = fakeStore()
   saveLocMarkers(cleared, store)
-  assert.equal(locMarkerFor(loadLocMarkers(store), 'oasis'), null)
+  assert.deepEqual(typedMarkersFor(loadLocMarkers(store), 'oasis'), [])
+})
+
+test('a LEGACY bare {ns,ew,z} loads as one blue TYPED marker — a pre-wave-3 marker survives upgrade', () => {
+  // Before the split, the box wrote a bare EqLoc under the zone key; it was always the typed mark.
+  const store = fakeStore({ [LOC_MARKERS_KEY]: JSON.stringify({ oasis: { ns: 613, ew: 51, z: 0 } }) })
+  assert.deepEqual(loadLocMarkers(store), { oasis: { typed: [{ loc: { ns: 613, ew: 51, z: 0 }, color: 'blue' }] } })
+})
+
+test('a wave-3 SINGLE typed reading loads as one blue typed marker', () => {
+  const store = fakeStore({ [LOC_MARKERS_KEY]: JSON.stringify({ sro: { typed: { ns: 1, ew: 2, z: 3 }, player: { ns: 4, ew: 5, z: 6 } } }) })
+  assert.deepEqual(loadLocMarkers(store), {
+    sro: { typed: [{ loc: { ns: 1, ew: 2, z: 3 }, color: 'blue' }], player: { ns: 4, ew: 5, z: 6 } }
+  })
 })
 
 test('a corrupt entry is dropped ALONE — one bad zone cannot take the others with it', () => {
   const store = fakeStore({
     [LOC_MARKERS_KEY]: JSON.stringify({
-      oasis: { ns: 613, ew: 51, z: 0 },
-      broken: { ns: 'north', ew: 51, z: 0 },
-      partial: { ns: 1 },
+      oasis: { typed: [{ loc: { ns: 613, ew: 51, z: 0 }, color: 'yellow' }], player: { ns: 1, ew: 2, z: 3 } },
+      legacy: { ns: 7, ew: 8, z: 9 }, // the bare pre-wave-3 shape, still read as one blue typed
+      halfBad: { typed: [{ loc: { ns: 'north', ew: 51, z: 0 } }, { loc: { ns: 4, ew: 5, z: 6 }, color: 'violet' }] },
+      duped: { typed: [{ loc: { ns: 1, ew: 1, z: 1 }, color: 'blue' }, { loc: { ns: 2, ew: 2, z: 2 }, color: 'blue' }] },
       nulled: null,
       wrong: 'nope',
-      '': { ns: 1, ew: 2, z: 3 }
+      '': { typed: [{ loc: { ns: 1, ew: 2, z: 3 }, color: 'blue' }] }
     })
   })
-  assert.deepEqual(loadLocMarkers(store), { oasis: { ns: 613, ew: 51, z: 0 } })
+  assert.deepEqual(loadLocMarkers(store), {
+    // A stored colour is honoured.
+    oasis: { typed: [{ loc: { ns: 613, ew: 51, z: 0 }, color: 'yellow' }], player: { ns: 1, ew: 2, z: 3 } },
+    legacy: { typed: [{ loc: { ns: 7, ew: 8, z: 9 }, color: 'blue' }] },
+    // The unreadable element drops; the good one keeps its stated colour.
+    halfBad: { typed: [{ loc: { ns: 4, ew: 5, z: 6 }, color: 'violet' }] },
+    // A duplicate colour is reassigned to the first unused one rather than dropped.
+    duped: { typed: [{ loc: { ns: 1, ew: 1, z: 1 }, color: 'blue' }, { loc: { ns: 2, ew: 2, z: 2 }, color: 'green' }] }
+  })
 })
 
 test('an absent, empty or unparseable store reads as no markers, never as a throw', () => {
@@ -317,6 +398,6 @@ test('an absent, empty or unparseable store reads as no markers, never as a thro
 test('the key is the one the app has shipped — a rename would silently drop every saved marker', () => {
   assert.equal(LOC_MARKERS_KEY, 'eq.maps.loc')
   const store = fakeStore()
-  saveLocMarkers({ oasis: { ns: 1, ew: 2, z: 3 } }, store)
-  assert.equal(store.data['eq.maps.loc'], '{"oasis":{"ns":1,"ew":2,"z":3}}')
+  saveLocMarkers(addTypedMarker({}, 'oasis', { ns: 1, ew: 2, z: 3 }), store)
+  assert.equal(store.data['eq.maps.loc'], '{"oasis":{"typed":[{"loc":{"ns":1,"ew":2,"z":3},"color":"blue"}]}}')
 })


### PR DESCRIPTION
![markers](https://raw.githubusercontent.com/bucketss/everquest-companion/pr-assets/markers.jpg)

Allows multiple markers to be placed on the map. Player marker (red) is scraped and updated automatically when players type /loc in game. The other 4 can be added manually, and cycle colors as needed.
