### PR TITLE
EQ discovery: the Daybreak launcher states the install dir as a FILE in it, and a machine can have three EverQuests

### DIFF
--- a/src/main/log/discovery.ts
+++ b/src/main/log/discovery.ts
@@ -72,6 +72,44 @@ export interface DiscoveryProbes {
 /** The character-log filename the game writes: `eqlog_<Char>_<server>.txt`. */
 const EQLOG_RE = /^eqlog_.+\.txt$/i
 
+/** A candidate path that names THIS game rather than one of its siblings. See `legendsFirst`. */
+const EQ_LEGENDS_PATH_RE = /everquest\s*legends/i
+
+/**
+ * THIS APP IS FOR EVERQUEST **LEGENDS**, AND A MACHINE CAN HAVE MORE THAN ONE EVERQUEST ON IT
+ * (2026-08-17). Stable-partition a tier of candidates so the ones whose path names Legends are
+ * probed first.
+ *
+ * MEASURED on the reporting machine, whose registry yields all of these and in this order:
+ *
+ *     C:\Users\wange\AppData\Local\Programs\everquest-companion   (this app's own uninstall entry)
+ *     D:\Games\EverQuest                                          (retail/Teek — 38 character logs)
+ *     D:\Games\EverQuest II
+ *     D:\Games\EverQuest Legends                                  (the one we want)
+ *
+ * `discoverEqRoot` returns the FIRST candidate that has logs, and `D:\Games\EverQuest` has 38 of
+ * them — so without this the registry lookup does not merely fail, it succeeds at tailing the
+ * WRONG GAME, which is a worse outcome than finding nothing (the user gets a confidently populated
+ * app full of data from a game this app does not model). `hasLogs` cannot break the tie: a retail
+ * EverQuest log directory is shaped exactly like a Legends one, same `eqlog_<Char>_<server>.txt`.
+ * The path is the only evidence available at this point, and where the path is silent (an install
+ * at `D:\Games\EQL`) the tie genuinely cannot be broken here — that is what the Settings override
+ * is for, and it always wins.
+ *
+ * WHY PER-TIER AND NOT ONE GLOBAL SORT: "an explicit env/registry candidate outranks the drive
+ * sweep" is its own precedence law, pinned by eqDiscovery.test.mts, and a registry candidate whose
+ * path happens not to say "Legends" (`E:\Games\EQL`) must still be probed before a swept public
+ * path that does. So each tier is partitioned on its own and the tiers stay in order. STABLE, so
+ * within a tier nothing else about the existing order changes — on a machine with exactly one
+ * EverQuest, every candidate lands in the same bucket and this is a no-op.
+ */
+export function legendsFirst(candidates: readonly string[]): string[] {
+  const named: string[] = []
+  const rest: string[] = []
+  for (const c of candidates) (EQ_LEGENDS_PATH_RE.test(c) ? named : rest).push(c)
+  return [...named, ...rest]
+}
+
 /**
  * THE OUTCOME OF READING A LOGS DIR — three answers, never two (JOS-82).
  *
@@ -315,14 +353,18 @@ export function discoverEqRoot(probes: DiscoveryProbes): string | null {
     candidates.push(c)
   }
 
-  for (const c of probes.extraCandidates()) push(c)
+  // Each tier is `legendsFirst`-partitioned on its own, so a path naming Legends outranks a
+  // sibling EverQuest install WITHIN its tier while the tiers keep their own precedence.
+  for (const c of legendsFirst(probes.extraCandidates())) push(c)
   // Skip generating (and thus probing) the drive-sweep candidates once we are already over
   // budget — the env/registry phase alone can spend it on a pathological Uninstall hive.
   if (!overBudget()) {
+    const swept: string[] = []
     for (const drive of probes.fixedDrives()) {
       const d = drive.replace(/[\\/]+$/, '')
-      for (const sub of DAYBREAK_SUBPATHS) push(`${d}\\${sub}`)
+      for (const sub of DAYBREAK_SUBPATHS) swept.push(`${d}\\${sub}`)
     }
+    for (const c of legendsFirst(swept)) push(c)
   }
 
   for (const c of candidates) {
@@ -521,6 +563,13 @@ export function fixedDrives(): string[] {
 const INSTALL_PATH_VALUES = ['InstallLocation', 'InstallPath', 'InstallDir'] as const
 
 /**
+ * The value names holding a FILE inside the install dir rather than the dir itself. The Daybreak
+ * launcher writes these and none of the three above — see `eqInstallDirFromFileValue` for the
+ * measured registry shape and why this list is exactly two names long.
+ */
+const INSTALL_FILE_VALUES = ['UninstallString', 'DisplayIcon'] as const
+
+/**
  * The game's name has to appear in the path itself for it to be a candidate. This is the
  * `reg query … /f EverQuest` filter, preserved EXACTLY — see `registryInstallCandidates`.
  */
@@ -575,6 +624,75 @@ export function eqInstallPathValue(value: unknown): string | null {
   return p && EQ_PATH_RE.test(p) ? p : null
 }
 
+/**
+ * THE DAYBREAK LAUNCHER WRITES NO `InstallLocation`, SO THE INSTALL DIR HAS TO COME OUT OF A FILE
+ * PATH — one `dirname` away, and this is that step.
+ *
+ * MEASURED on a reporter's machine (2026-08-17, Windows 11 10.0.26200), a real EQ Legends install
+ * at `D:\Games\EverQuest Legends` that discovery could not find AT ALL. The registry knew exactly
+ * where it was; the values above were simply not the ones it used:
+ *
+ *   HKCU\…\CurrentVersion\Uninstall\DGC-EverQuest Legends
+ *       DisplayName        EverQuest Legends
+ *       UninstallString    D:\Games\EverQuest Legends\Uninstaller.exe
+ *       DisplayIcon        D:\Games\EverQuest Legends\Everquest.ico
+ *
+ * No `InstallLocation`, no `InstallPath`, no `InstallDir` — so `eqInstallPathValue` could never
+ * fire, and the drive sweep's `DAYBREAK_SUBPATHS` do not contain a `Games\` layout either. The
+ * `DGC-` prefix is the Daybreak launcher's own key-naming convention (`DGC-EverQuest`,
+ * `DGC-EverQuest II`, `DGC-EverQuest Legends` all present on that box), so this shape is the
+ * launcher's, not one machine's peculiarity.
+ *
+ * WHY THE FILTER STAYS ON THE RAW VALUE, not on the derived directory: that is exactly what
+ * `eqInstallPathValue` does, and it is the more permissive of the two — an `EverQuest.exe` sitting
+ * in a folder whose own name never says so still yields its folder as a CANDIDATE. Being a
+ * candidate costs one `readdir`; `hasLogs` is what actually decides, and it is the only thing that
+ * should. The same permissiveness admits the harmless near-misses this necessarily picks up (an
+ * EverQuest II install, and this app's OWN uninstall entry, whose InstallLocation says
+ * "everquest-companion") — none of them hold a `Logs\eqlog_*.txt` and all of them fail the probe.
+ *
+ * PURE, and separated from the registry walk, so the command-line shapes below are a unit test
+ * rather than a claim about someone's machine.
+ */
+export function eqInstallDirFromFileValue(value: unknown): string | null {
+  if (typeof value !== 'string') return null
+  const raw = value.trim()
+  if (!raw || !EQ_PATH_RE.test(raw)) return null
+  const file = programPathFromCommand(raw)
+  if (file === null) return null
+  const dir = parentDir(file)
+  // `parentDir` hands back its argument unchanged when there is no separator at all (a bare
+  // `Uninstaller.exe`), which is not a directory and must not become a candidate.
+  return dir === file ? null : dir
+}
+
+/**
+ * The program/icon path out of one of those values. Three shapes, and the order matters:
+ *
+ *   1. `"C:\…\Uninstall EQ.exe" /currentuser` — QUOTED. The quotes are the delimiter, so this is
+ *      the only shape where arguments can be split off unambiguously, and it is tried first.
+ *   2. `C:\…\App.exe,0` — `DisplayIcon`'s optional icon INDEX (negative indices are legal too).
+ *   3. `D:\Games\EverQuest Legends\Uninstaller.exe /S` — UNQUOTED, and the path may itself contain
+ *      spaces (the measured case does). Splitting on whitespace would cut `EverQuest Legends` in
+ *      half, so the file EXTENSION is the only reliable cut. Lazy, so the FIRST extension wins and
+ *      an argument that is itself a path cannot extend the match.
+ *
+ * Anything with no recognizable executable/icon extension returns null rather than a guess — a
+ * wrong directory here would be probed, fail `hasLogs`, and cost nothing, but inventing a path
+ * shape nobody has observed is how a matcher starts drifting.
+ */
+function programPathFromCommand(raw: string): string | null {
+  if (raw.startsWith('"')) {
+    const close = raw.indexOf('"', 1)
+    if (close < 0) return null
+    const quoted = raw.slice(1, close).trim()
+    return quoted === '' ? null : quoted
+  }
+  const withoutIconIndex = raw.replace(/,\s*-?\d+\s*$/, '')
+  const m = /^(.*?\.(?:exe|ico|dll|cmd|bat))(?:\s|$)/i.exec(withoutIconIndex)
+  return m ? m[1] : null
+}
+
 /** Open a key defensively — a missing key, a denied ACL and a malformed path are all `null`. */
 function openKey(reg: typeof NativeReg, parent: NativeReg.HKEY, path: string): NativeReg.HKEY | null {
   try {
@@ -625,22 +743,42 @@ interface RegistrySweep {
 }
 
 /**
+ * The candidates stated by ONE key's OWN values — the two decoders, over their two value lists.
+ *
+ * Split out of `collectInstallPaths` so that function stays under the complexity ceiling and so the
+ * "read a value defensively" wrapper is written once instead of per list. A value we cannot read is
+ * simply not a source of candidates.
+ *
+ * ORDER IS PRECEDENCE: the explicit install-DIR values run first, so a key carrying both an
+ * `InstallLocation` and an `UninstallString` yields the explicit one ahead of the derived one.
+ * `discoverEqRoot` returns the first candidate that has logs.
+ */
+function collectKeyOwnValues(key: NativeReg.HKEY, sweep: RegistrySweep): void {
+  const read = (name: string): unknown => {
+    try {
+      return sweep.reg.getValue(key, null, name)
+    } catch {
+      return undefined
+    }
+  }
+  for (const name of INSTALL_PATH_VALUES) {
+    const path = eqInstallPathValue(read(name))
+    if (path) sweep.out.push(path)
+  }
+  for (const name of INSTALL_FILE_VALUES) {
+    const dir = eqInstallDirFromFileValue(read(name))
+    if (dir) sweep.out.push(dir)
+  }
+}
+
+/**
  * Collect install paths from `key` and (to `MAX_KEY_DEPTH`) its subkeys. Every registry call is
  * wrapped: a key we cannot read is simply not a source of candidates.
  */
 function collectInstallPaths(key: NativeReg.HKEY, depth: number, sweep: RegistrySweep): void {
   const reg = sweep.reg
   if (sweep.visited++ >= MAX_KEYS_VISITED || Date.now() >= sweep.deadline) return
-  for (const name of INSTALL_PATH_VALUES) {
-    let raw: unknown
-    try {
-      raw = reg.getValue(key, null, name)
-    } catch {
-      continue
-    }
-    const path = eqInstallPathValue(raw)
-    if (path) sweep.out.push(path)
-  }
+  collectKeyOwnValues(key, sweep)
   if (depth >= MAX_KEY_DEPTH) return
   let subKeys: string[]
   try {
@@ -663,8 +801,11 @@ function collectInstallPaths(key: NativeReg.HKEY, depth: number, sweep: Registry
 /**
  * Probe the Windows registry (defensively) for an EverQuest / Daybreak install location. Checks the
  * standard Uninstall hives (both HKLM 64/32-bit views and HKCU) plus Daybreak/SOE launcher keys.
- * Returns any `InstallLocation` / `InstallPath` / `InstallDir` value that names EverQuest — most
- * machines have none (the game is a public-folder install), which is fine.
+ * Returns any `InstallLocation` / `InstallPath` / `InstallDir` value that names EverQuest, plus the
+ * containing directory of any `UninstallString` / `DisplayIcon` that does — the Daybreak launcher
+ * writes only the latter kind (`eqInstallDirFromFileValue` carries the measured key). Plenty of
+ * machines have neither and resolve through the drive sweep instead, which is fine and is the
+ * documented normal for a default public-folder install.
  *
  * IN-PROCESS AND SCOPED SINCE JOS-184. This was EIGHT synchronous `reg.exe query … /s /f EverQuest`
  * subprocesses: a recursive TEXT SEARCH of the whole Uninstall hive whose stdout we then grepped

--- a/tests/eqDiscovery.test.mts
+++ b/tests/eqDiscovery.test.mts
@@ -21,6 +21,7 @@ import { tmpdir } from 'os'
 import { join } from 'path'
 import {
   discoverEqRoot,
+  legendsFirst,
   rootHasLogs,
   countCharacterLogs,
   dirHasCharacterLogs,
@@ -62,6 +63,37 @@ test('discoverEqRoot: an extra candidate (env/registry) wins over the drive swee
   // BOTH have logs; the extra candidate is probed first, so it wins.
   const root = discoverEqRoot(probes(new Set([lc(reg), lc(publicPath)]), ['C:'], [reg]))
   assert.equal(root, reg)
+})
+
+test('discoverEqRoot: a sibling EverQuest with logs never outranks the Legends install', () => {
+  // THE REGRESSION, measured 2026-08-17 on a machine that has three EverQuests installed. The
+  // registry hands back its Uninstall entries in key order, so retail EverQuest arrives BEFORE
+  // EverQuest Legends — and retail had 38 character logs in it. First-hit-wins therefore did not
+  // fail to find a game, it found the WRONG one and would have tailed it confidently. `hasLogs`
+  // cannot break this tie: both directories hold real `eqlog_<Char>_<server>.txt` files, which is
+  // why BOTH are marked as having logs here.
+  const retail = 'D:\\Games\\EverQuest'
+  const legends = 'D:\\Games\\EverQuest Legends'
+  const companion = 'C:\\Users\\u\\AppData\\Local\\Programs\\everquest-companion'
+  const root = discoverEqRoot(
+    probes(new Set([lc(retail), lc(legends)]), ['C:'], [companion, retail, 'D:\\Games\\EverQuest II', legends])
+  )
+  assert.equal(root, legends)
+})
+
+test('legendsFirst: a stable partition — no-op on a machine with one EverQuest', () => {
+  // Stability is the property that keeps this change invisible everywhere it is not needed.
+  assert.deepEqual(legendsFirst(['C:\\A', 'C:\\B', 'C:\\C']), ['C:\\A', 'C:\\B', 'C:\\C'])
+  assert.deepEqual(
+    legendsFirst(['D:\\Games\\EverQuest', 'D:\\Games\\EverQuest II', 'D:\\Games\\EverQuest Legends']),
+    ['D:\\Games\\EverQuest Legends', 'D:\\Games\\EverQuest', 'D:\\Games\\EverQuest II']
+  )
+  // Order among the Legends paths, and among the rest, is untouched.
+  assert.deepEqual(
+    legendsFirst(['A\\EverQuest', 'B\\EverQuest Legends', 'C\\Other', 'D\\EverQuestLegends']),
+    ['B\\EverQuest Legends', 'D\\EverQuestLegends', 'A\\EverQuest', 'C\\Other']
+  )
+  assert.deepEqual(legendsFirst([]), [])
 })
 
 test('discoverEqRoot: returns null when nothing has logs (fresh machine)', () => {

--- a/tests/eqDiscoveryCache.test.mts
+++ b/tests/eqDiscoveryCache.test.mts
@@ -131,25 +131,33 @@ test('discoverEqRoot: a candidate found BEFORE the deadline is still returned', 
 test('discoverEqRoot: a single blocking (offline-share) probe caps the whole call', () => {
   // The reported hang, in miniature: the FIRST candidate is an offline mapped drive whose readdir
   // blocks past the entire budget. The real install sits behind it — and must NOT be waited for.
+  //
+  // THE BLOCKING CANDIDATE NAMES LEGENDS ON PURPOSE (2026-08-17). `legendsFirst` partitions each
+  // tier, so a stale `Z:\offline` that did not name the game would now be reordered BEHIND the
+  // real install and this test would stop exercising the ceiling it exists for — it would pass on
+  // the ordering rather than on the budget. Both candidates sitting in the same partition bucket
+  // keeps the blocking one genuinely first, which is what makes the assertions below mean
+  // something. It is also the more faithful shape: the share that hung was somebody's EQ install.
   let clock = 0
   const probed: string[] = []
+  const offlineShare = 'Z:\\Games\\EverQuest Legends'
   const realInstall = 'C:\\Users\\Public\\Daybreak Game Company\\Installed Games\\EverQuest Legends'
   const root = discoverEqRoot({
     hasLogs: (c): boolean => {
       probed.push(c)
-      if (c === 'Z:\\offline') {
+      if (c === offlineShare) {
         clock += 30_000 // the SMB timeout
         return false
       }
       return c === realInstall
     },
-    extraCandidates: () => ['Z:\\offline', realInstall],
+    extraCandidates: () => [offlineShare, realInstall],
     fixedDrives: () => [],
     budgetMs: 6_000,
     now: () => clock
   })
   assert.equal(root, null, 'the one blocking probe exhausts the budget; we do not hang on the rest')
-  assert.deepEqual(probed, ['Z:\\offline'], 'the real install behind it is never reached')
+  assert.deepEqual(probed, [offlineShare], 'the real install behind it is never reached')
 })
 
 test('discoverEqRoot: a filtered (non-fixed) drive is never probed at all', () => {

--- a/tests/eqDiscoveryProbes.test.mts
+++ b/tests/eqDiscoveryProbes.test.mts
@@ -23,6 +23,7 @@ import { test } from 'node:test'
 import assert from 'node:assert/strict'
 import {
   driveLettersFromMountedDevices,
+  eqInstallDirFromFileValue,
   eqInstallPathValue,
   fixedDrives,
   networkDriveLetters,
@@ -60,6 +61,60 @@ test('eqInstallPathValue: keeps a path that names the game, in the same cases re
   assert.equal(eqInstallPathValue(undefined), null)
   assert.equal(eqInstallPathValue(1), null)
   assert.equal(eqInstallPathValue(['C:\\EverQuest']), null)
+})
+
+test('eqInstallDirFromFileValue: the Daybreak launcher states the install dir as a FILE in it', () => {
+  // THE REGRESSION THIS EXISTS FOR, verbatim from the reporting machine (Windows 11 10.0.26200,
+  // 2026-08-17): a real `D:\Games\EverQuest Legends` install that discovery missed completely,
+  // because the launcher's Uninstall key carries NO InstallLocation/InstallPath/InstallDir. Both
+  // of the values it does carry name the folder one `dirname` up.
+  assert.equal(
+    eqInstallDirFromFileValue('D:\\Games\\EverQuest Legends\\Uninstaller.exe'),
+    'D:\\Games\\EverQuest Legends'
+  )
+  assert.equal(
+    eqInstallDirFromFileValue('D:\\Games\\EverQuest Legends\\Everquest.ico'),
+    'D:\\Games\\EverQuest Legends'
+  )
+  // The three command-line shapes, in the order `programPathFromCommand` tries them.
+  // 1. QUOTED program path with arguments after it — the only unambiguous split.
+  assert.equal(
+    eqInstallDirFromFileValue('"C:\\Games\\EverQuest\\Uninstall EverQuest.exe" /currentuser'),
+    'C:\\Games\\EverQuest'
+  )
+  // 2. DisplayIcon's icon INDEX, positive and negative.
+  assert.equal(eqInstallDirFromFileValue('D:\\Games\\EverQuest\\EQ.exe,0'), 'D:\\Games\\EverQuest')
+  assert.equal(eqInstallDirFromFileValue('D:\\Games\\EverQuest\\EQ.exe,-101'), 'D:\\Games\\EverQuest')
+  // 3. UNQUOTED, with arguments, and a SPACE IN THE PATH — the shape that makes splitting on
+  //    whitespace wrong. The extension is the cut, and it is lazy, so an argument that is itself a
+  //    path cannot extend the match.
+  assert.equal(
+    eqInstallDirFromFileValue('D:\\Games\\EverQuest Legends\\Uninstaller.exe /S'),
+    'D:\\Games\\EverQuest Legends'
+  )
+  assert.equal(
+    eqInstallDirFromFileValue('D:\\Games\\EverQuest\\un.exe /log C:\\other\\place.exe'),
+    'D:\\Games\\EverQuest'
+  )
+  // Forward slashes: these values reach us from installers of every vintage.
+  assert.equal(eqInstallDirFromFileValue('D:/Games/EverQuest/un.exe'), 'D:/Games/EverQuest')
+
+  // THE FILTER IS THE SAME ONE, ON THE RAW VALUE — a path that never names the game is not a
+  // candidate however well-formed it is.
+  assert.equal(eqInstallDirFromFileValue('C:\\Program Files\\Steam\\steam.exe'), null)
+  // No recognizable extension ⇒ null, never a guess at where the path ends.
+  assert.equal(eqInstallDirFromFileValue('D:\\Games\\EverQuest\\somefile'), null)
+  // A bare filename has no containing directory to offer.
+  assert.equal(eqInstallDirFromFileValue('EverQuest.exe'), null)
+  // An unterminated quote is malformed, not a path.
+  assert.equal(eqInstallDirFromFileValue('"D:\\Games\\EverQuest\\un.exe'), null)
+  // Empty / whitespace-only / non-string values, exactly as `eqInstallPathValue` refuses them.
+  assert.equal(eqInstallDirFromFileValue(''), null)
+  assert.equal(eqInstallDirFromFileValue('   '), null)
+  assert.equal(eqInstallDirFromFileValue(null), null)
+  assert.equal(eqInstallDirFromFileValue(undefined), null)
+  assert.equal(eqInstallDirFromFileValue(1), null)
+  assert.equal(eqInstallDirFromFileValue(['D:\\EverQuest\\un.exe']), null)
 })
 
 test('registryInstallCandidates: reads the machine in-process, never throws, honours the ceiling', () => {


### PR DESCRIPTION
My EQ Legends install at `D:\Games\EverQuest Legends` was invisible to discovery — and the registry knew where it was the whole time. Two separate misses, both measured on my machine (Windows 11 10.0.26200):

**1. The values.** `INSTALL_PATH_VALUES` reads `InstallLocation` / `InstallPath` / `InstallDir`, and the Daybreak launcher writes none of them. It writes `UninstallString` and `DisplayIcon`, which both name a *file* inside the install dir — so the dir is one `dirname` up. `eqInstallDirFromFileValue` is that step, kept pure so the command-line shapes are unit-testable: quoted-with-args, `DisplayIcon`'s `,0` icon index, and unquoted-with-args where the path itself contains a space.

**2. Which EverQuest.** With (1) fixed, discovery resolved to `D:\Games\EverQuest` — retail/Teek, 38 character logs, ahead of Legends in registry key order. First-hit-wins doesn't fail there, it succeeds at tailing the *wrong game*. `hasLogs` can't break the tie since a retail log dir looks identical. `legendsFirst` stable-partitions each tier so a path naming Legends is probed first — per tier, so "explicit candidate outranks the drive sweep" still holds.

The drive sweep is deliberately untouched and still runs only after the registry misses. One existing test (`eqDiscoveryCache`) was renamed rather than re-asserted; the commit message says why.

Verified at `90ab31a9`: typecheck clean, lint clean with no ratchet entry, 5439 tests / 5413 pass / 0 fail / 26 skipped, build clean. Branch is on current main (`3bdf5baf`).

Happy to split, reword, or drop any of it.
