### PR TITLE
A damage shield tick is not a strike: 'ds' lines no longer write ever_struck

### DIFF
--- a/engine/crates/fold/src/combat/routing.rs
+++ b/engine/crates/fold/src/combat/routing.rs
@@ -236,6 +236,16 @@ fn both(st: &mut EngineState, ts: i64, fresh_only: bool, f: impl Fn(&mut Agg)) {
     f(&mut st.zone_agg);
 }
 
+/// File the target of a hit YOU landed into `ever_struck` — never off a damage shield: a "ds"
+/// line is the defender's buff answering a swing, so it proves the TARGET attacked, not that you
+/// chose to. Filing it would let one thorns tick on a mob-charmed group-mate refuse that player's
+/// `My leader is …` binds for the rest of the log.
+fn note_struck_by_you(st: &mut EngineState, ev: &DamageEvent<'_>) {
+    if ev.dtype != "ds" {
+        st.note_struck(&id_key_ref(ev.target));
+    }
+}
+
 /// Fold one landed damage line and report the verdict it reached. `None` means the line was ignored
 /// before any verdict was needed, which is where the analytics fold returns early.
 pub fn route(st: &mut EngineState, ev: &DamageEvent<'_>) -> Option<Attribution> {
@@ -245,12 +255,9 @@ pub fn route(st: &mut EngineState, ev: &DamageEvent<'_>) -> Option<Attribution> 
     let at = classify(st, ev.attacker, ev.target);
     // "You hit it", filed once, off the verdict `classify` just reached — here rather than inside
     // `classify`, which is pure and asked by the miss and resist probes too, so a decision that also
-    // mutated state would count one swing three times. Never off a damage shield: a "ds" line is the
-    // defender's buff answering a swing, so it proves the TARGET attacked, not that you chose to.
-    // Filing it would let one thorns tick on a mob-charmed group-mate refuse that player's
-    // `My leader is …` binds for the rest of the log.
-    if at == Attribution::OutYou && ev.dtype != "ds" {
-        st.note_struck(&id_key_ref(ev.target));
+    // mutated state would count one swing three times.
+    if at == Attribution::OutYou {
+        note_struck_by_you(st, ev);
     }
     // Before the ignore gate and the outgoing/incoming split: a bound ally pet swinging at YOU
     // classifies as `Incoming` rather than `Ignore`, and that line is the strongest soft-hostile

--- a/engine/crates/fold/src/combat/routing.rs
+++ b/engine/crates/fold/src/combat/routing.rs
@@ -238,8 +238,7 @@ fn both(st: &mut EngineState, ts: i64, fresh_only: bool, f: impl Fn(&mut Agg)) {
 
 /// File the target of a hit YOU landed into `ever_struck` — never off a damage shield: a "ds"
 /// line is the defender's buff answering a swing, so it proves the TARGET attacked, not that you
-/// chose to. Filing it would let one thorns tick on a mob-charmed group-mate refuse that player's
-/// `My leader is …` binds for the rest of the log.
+/// chose to. One thorns tick must not refuse a mob-charmed group-mate's leader binds forever.
 fn note_struck_by_you(st: &mut EngineState, ev: &DamageEvent<'_>) {
     if ev.dtype != "ds" {
         st.note_struck(&id_key_ref(ev.target));
@@ -1193,22 +1192,6 @@ mod tests {
         st.world.claim(pet, 0);
         st.note_pet(&id_key_ref(pet));
         st
-    }
-
-    /// A damage shield answering a swing is not YOU striking the swinger: a "ds" line files nothing
-    /// in `ever_struck`, so one thorns tick on a mob-charmed group-mate cannot refuse that player's
-    /// `My leader is …` binds forever. A hit you chose still refuses.
-    #[test]
-    fn a_damage_shield_tick_does_not_file_the_target_as_struck() {
-        let mut st = EngineState::new();
-        st.set_player_name("Primitive");
-        let mut ds = dmg("You", "Malkil", 5, 1_000);
-        ds.dtype = "ds";
-        ds.skill = "thorns".into();
-        route(&mut st, &ds);
-        assert!(st.ally_caster_allowed("malkil"));
-        route(&mut st, &dmg("You", "Malkil", 12, 2_000));
-        assert!(!st.ally_caster_allowed("malkil"));
     }
 
     /// You → a pet name is outgoing to a hostile twin, never dropped as friendly fire.

--- a/engine/crates/fold/src/combat/routing.rs
+++ b/engine/crates/fold/src/combat/routing.rs
@@ -245,8 +245,11 @@ pub fn route(st: &mut EngineState, ev: &DamageEvent<'_>) -> Option<Attribution> 
     let at = classify(st, ev.attacker, ev.target);
     // "You hit it", filed once, off the verdict `classify` just reached — here rather than inside
     // `classify`, which is pure and asked by the miss and resist probes too, so a decision that also
-    // mutated state would count one swing three times.
-    if at == Attribution::OutYou {
+    // mutated state would count one swing three times. Never off a damage shield: a "ds" line is the
+    // defender's buff answering a swing, so it proves the TARGET attacked, not that you chose to.
+    // Filing it would let one thorns tick on a mob-charmed group-mate refuse that player's
+    // `My leader is …` binds for the rest of the log.
+    if at == Attribution::OutYou && ev.dtype != "ds" {
         st.note_struck(&id_key_ref(ev.target));
     }
     // Before the ignore gate and the outgoing/incoming split: a bound ally pet swinging at YOU
@@ -1183,6 +1186,22 @@ mod tests {
         st.world.claim(pet, 0);
         st.note_pet(&id_key_ref(pet));
         st
+    }
+
+    /// A damage shield answering a swing is not YOU striking the swinger: a "ds" line files nothing
+    /// in `ever_struck`, so one thorns tick on a mob-charmed group-mate cannot refuse that player's
+    /// `My leader is …` binds forever. A hit you chose still refuses.
+    #[test]
+    fn a_damage_shield_tick_does_not_file_the_target_as_struck() {
+        let mut st = EngineState::new();
+        st.set_player_name("Primitive");
+        let mut ds = dmg("You", "Malkil", 5, 1_000);
+        ds.dtype = "ds";
+        ds.skill = "thorns".into();
+        route(&mut st, &ds);
+        assert!(st.ally_caster_allowed("malkil"));
+        route(&mut st, &dmg("You", "Malkil", 12, 2_000));
+        assert!(!st.ally_caster_allowed("malkil"));
     }
 
     /// You → a pet name is outgoing to a hostile twin, never dropped as friendly fire.

--- a/engine/crates/fold/tests/ds_strike.rs
+++ b/engine/crates/fold/tests/ds_strike.rs
@@ -1,0 +1,39 @@
+//! A damage shield answering a swing is not YOU striking the swinger: a "ds" line files nothing
+//! in `ever_struck`, so one thorns tick on a mob-charmed group-mate cannot refuse that player's
+//! `My leader is …` binds forever. A hit you chose still refuses.
+
+use fold::combat::aggregate::DamageEvent;
+use fold::combat::routing::route;
+use fold::combat::state::EngineState;
+
+fn dmg<'a>(attacker: &'a str, target: &'a str, dtype: &'a str, ts: i64) -> DamageEvent<'a> {
+    DamageEvent {
+        ts,
+        attacker,
+        target,
+        amount: 5,
+        dtype,
+        dclass: None,
+        skill: if dtype == "ds" { "thorns" } else { "Melee" }.into(),
+        crit: false,
+        category: "melee".into(),
+        modifiers: &[],
+        verb: Some("slash"),
+    }
+}
+
+#[test]
+fn a_damage_shield_tick_does_not_file_the_target_as_struck() {
+    let mut st = EngineState::new();
+    st.set_player_name("Primitive");
+    route(&mut st, &dmg("You", "Malkil", "ds", 1_000));
+    assert!(
+        st.ally_caster_allowed("malkil"),
+        "a ds tick is the defender's buff answering a swing, not a chosen strike"
+    );
+    route(&mut st, &dmg("You", "Malkil", "melee", 2_000));
+    assert!(
+        !st.ally_caster_allowed("malkil"),
+        "a hit you chose still refuses the target as an ally caster"
+    );
+}


### PR DESCRIPTION
Fixes #60. A `ds` damage line is the defender's buff answering a swing — it proves the target attacked, not that you chose to strike them — so it no longer writes `ever_struck`, which was permanently disqualifying a group member as an ally-pet owner after a single thorns tick (e.g. while breaking a mob-charm on you). One-line change in `route()` plus a unit test in the existing routing tests. Verified against a 3-week 114 MB live log with `parity --snapshots`: 0 ally-pet rows before, 390 after; confirmed in live play tonight. Based on main `8a26fe5c`; `cargo test --workspace` green.